### PR TITLE
API Skip existing tags so that failed publishes can be safely resumed

### DIFF
--- a/src/Model/Module.php
+++ b/src/Model/Module.php
@@ -188,6 +188,19 @@ class Module
     }
 
     /**
+     * Gets all tags that exist in the repository
+     *
+     * @return array
+     */
+    public function getTags()
+    {
+        $repo = $this->getRepository();
+        $result = $repo->run('tag');
+        $tags = preg_split('~\R~u', $result);
+        return array_filter($tags);
+    }
+
+    /**
      * Tag this module
      *
      * @param string $tag

--- a/src/Steps/Release/TagModules.php
+++ b/src/Steps/Release/TagModules.php
@@ -46,11 +46,17 @@ class TagModules extends ModuleStep
 
     public function run(InputInterface $input, OutputInterface $output)
     {
-        $this->log($output, "Tagging modules as " . $this->getVersion()->getValue());
+        $tag = $this->getVersion()->getValue();
+        $this->log($output, "Tagging modules as " . $tag);
 
         foreach ($this->getModules() as $module) {
             $this->log($output, "Tagging module " . $module->getName());
-            $module->addTag($this->getVersion()->getValue());
+            $tags = $module->getTags();
+            if(in_array($tag, $tags)) {
+                $this->log($output, "Skipping existing tag: <info>{$tag}</info>");
+            } else {
+                $module->addTag($tag);
+            }
         }
         
         $this->log($output, 'Tagging complete');


### PR DESCRIPTION
This is necessary so that `cow release:publish` can be resumed if (for instance) a packagist error failed to find the newly tagged release.