### PR TITLE
API checkout:branch now includes modules that aren't self.version

### DIFF
--- a/src/Commands/Branch/Checkout.php
+++ b/src/Commands/Branch/Checkout.php
@@ -37,6 +37,7 @@ class Checkout extends Module
         $remote = $this->getInputRemote();
 
         $merge = new CheckoutBranch($this, $directory, $modules, $listIsExclusive, $branch, $remote);
+        $merge->setVersionConstraint(null); // checkout:branch doesn't filter by self.version
         $merge->run($this->input, $this->output);
     }
 


### PR DESCRIPTION
Without this asset-admin wasn't being checked out properly, as it has the `^1` constraint.