### PR TITLE
NEW Allow release title to be set

### DIFF
--- a/src/Commands/Module/Tag.php
+++ b/src/Commands/Module/Tag.php
@@ -23,6 +23,7 @@ class Tag extends Command
         $this->addArgument('version', InputArgument::REQUIRED, 'Version tag');
         $this->addOption('from', 'f', InputOption::VALUE_REQUIRED, 'Version to generate changelog from');
         $this->addOption('directory', 'd', InputOption::VALUE_REQUIRED, 'Project root directory');
+        $this->addOption('message', 'm', InputOption::VALUE_REQUIRED, 'Release title to display on GitHub releases page');
     }
 
     /**
@@ -34,8 +35,9 @@ class Tag extends Command
         $module = $this->getInputModule();
         $directory = $this->getInputDirectory();
         $fromVersion = $this->getInputFromVersion($version);
+        $message = $this->getInputMessage();
 
-        $step = new TagAnnotatedModule($this, $version, $fromVersion, $directory, $module);
+        $step = new TagAnnotatedModule($this, $version, $fromVersion, $directory, $module, $message);
         $step->run($this->input, $this->output);
     }
 
@@ -91,5 +93,15 @@ class Tag extends Command
     protected function getInputModule()
     {
         return $this->input->getArgument('module');
+    }
+
+    /**
+     * Message title to use when tagging the release
+     *
+     * @return string
+     */
+    protected function getInputMessage()
+    {
+        return $this->input->getArgument('message');
     }
 }

--- a/src/Steps/Module/TagAnnotatedModule.php
+++ b/src/Steps/Module/TagAnnotatedModule.php
@@ -49,6 +49,11 @@ class TagAnnotatedModule extends Step
     protected $module;
 
     /**
+     * @var string
+     */
+    protected $message;
+
+    /**
      * @return Module
      */
     public function getModule()
@@ -120,17 +125,34 @@ class TagAnnotatedModule extends Step
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getMessage() {
+        return $this->message ?: $this->getVersion()->getValue();
+    }
+
+    /**
+     * @param $message string
+     * @return $this
+     */
+    public function setMessage($message) {
+        $this->message = $message;
+        return $this;
+    }
+
     public function getStepName()
     {
         return 'tag-annotated';
     }
 
-    public function __construct(Command $command, ReleaseVersion $version, ReleaseVersion $from, $directory, $module)
+    public function __construct(Command $command, ReleaseVersion $version, ReleaseVersion $from, $directory, $module, $message)
     {
         parent::__construct($command);
         $this->setVersion($version);
         $this->setFrom($from);
         $this->setProject(new Project($directory));
+        $this->setMessage($message);
         $module = $this->getProject()->getModule($module);
         if (empty($module)) {
             throw new \InvalidArgumentException("No module $module found in project");
@@ -209,7 +231,7 @@ class TagAnnotatedModule extends Step
         $result = $reposAPI->releases()->create($org, $repo, [
             'tag_name' => $version->getValue(),
             'target_commitish' => $sha,
-            'name' => $version->getValue(),
+            'name' => $this->getMessage(),
             'body' => $markdown,
             'prerelease' => in_array($version->getStability(), ['rc', 'beta', 'alpha']),
             'draft' => false,


### PR DESCRIPTION
This adds the ability to set the title of the tag much like you would if tagging by hand.

Rather than releases always being named the same as their tag name, we can name them independently if we want to - this is useful for bug fix tags.

eg: `cow module:tag blog 2.4.4 -m 'Casting fixes'` would result in a tag 2.4.4 but with the release title "Casting fixes"