### PR TITLE
Update to stable requirments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "gitonomy/gitlib": "~1.0",
     "psr/log": "^1",
     "knplabs/github-api": "^2.0",
-    "php-http/guzzle6-adapter": "^1.2"
+    "php-http/guzzle6-adapter": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4@stable"


### PR DESCRIPTION
php-http/guzzle6-adapter:^1.2 is not a tagged release - analysing the [diff between 1.1 and dev-master (1.2.x-dev)](https://github.com/php-http/guzzle6-adapter/compare/v1.1.1...master) it's only changes to tests at the moment.

This change allows default global installation to work (without having to globally allow dev deps).