### PR TITLE
BUG Fix changelog generation failing on exact historic version constraint

### DIFF
--- a/src/Model/Release/ComposerConstraint.php
+++ b/src/Model/Release/ComposerConstraint.php
@@ -154,7 +154,11 @@ class ComposerConstraint
         );
 
         // Semver to
-        if ($parsed['type'] === '^') {
+        if (empty($parsed['type'])) {
+            // x.y.z@stable
+            $to = $from;
+        } elseif ($parsed['type'] === '^') {
+            // ^x.y.z
             $to = $parsed['major'] . '.99999.99999';
         } elseif (isset($parsed['patch']) && strlen($parsed['patch'])) {
             // ~x.y.z
@@ -201,7 +205,7 @@ class ComposerConstraint
 
         // Match semver constraint
         $valid = preg_match(
-            '/^(?<type>[~^])(?<major>\d+)(\\.(?<minor>\d+)(\\.(?<patch>\\d+))?)?'
+            '/^(?<type>[~^]?)(?<major>\d+)(\\.(?<minor>\d+)(\\.(?<patch>\\d+))?)?'
             . '([-@](?<stability>rc|alpha|beta|stable)(?<stabilityVersion>\d+)?)?$/',
             $version,
             $matches

--- a/tests/Model/Release/ComposerConstraintTest.php
+++ b/tests/Model/Release/ComposerConstraintTest.php
@@ -76,6 +76,25 @@ class ComposerConstraintTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('4.99999.99999', $constraint->getMaxVersion()->getValue());
     }
 
+    public function testParseExact()
+    {
+        $constraint = new ComposerConstraint('4.1.1@stable');
+        $this->assertEquals('4.1.1', $constraint->getMinVersion()->getValue());
+        $this->assertEquals('4.1.1', $constraint->getMaxVersion()->getValue());
+
+        $constraint = new ComposerConstraint('4.1.1');
+        $this->assertEquals('4.1.1', $constraint->getMinVersion()->getValue());
+        $this->assertEquals('4.1.1', $constraint->getMaxVersion()->getValue());
+
+        $constraint = new ComposerConstraint('4.1.1-rc3');
+        $this->assertEquals('4.1.1-rc3', $constraint->getMinVersion()->getValue());
+        $this->assertEquals('4.1.1-rc3', $constraint->getMaxVersion()->getValue());
+
+        $constraint = new ComposerConstraint('4.1.1@beta2');
+        $this->assertEquals('4.1.1-beta2', $constraint->getMinVersion()->getValue());
+        $this->assertEquals('4.1.1-beta2', $constraint->getMaxVersion()->getValue());
+    }
+
     public function testParseDev()
     {
         $constraint = new ComposerConstraint('4.1.x-dev');


### PR DESCRIPTION
E.g. ‘1.5.0@stable’