### PR TITLE
API Implement vendor modules / branch strategy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,11 @@ This command has these options:
 * `--directory <directory>` to specify the folder to create or look for this project in. If you don't specify this,
 it will install to the path specified by `./release-<version>` in the current directory.
 * `--repository <repository>` will allow a custom composer package url to be specified. E.g. `http://packages.cwp.govt.nz`
+* `--branching <type>` will specify a branching strategy. This allows these options:
+  * `auto` - Default option, will branch to the minor version (e.g. 1.1) unless doing a non-stable tag (e.g. rc1)
+  * `major` - Branch all repos to the major version (e.g. 1) unless already on a more-specific minor version.
+  * `minor` - Branch all repos to the minor semver branch (e.g. 1.1)
+  * `none` - Release from the current branch and do no branching.
 
 `release` actually has several sub-commands which can be run independently. These are as below:
 

--- a/src/Commands/Release/Branch.php
+++ b/src/Commands/Release/Branch.php
@@ -67,11 +67,6 @@ class Branch extends Release
         self::NONE => self::NONE_DESCRIPTION,
     ];
 
-    /**
-     * Default branch option
-     */
-    const DEFAULT_OPTION = self::AUTO;
-
     protected function fire()
     {
         // Get arguments

--- a/src/Commands/Release/Branch.php
+++ b/src/Commands/Release/Branch.php
@@ -17,14 +17,70 @@ class Branch extends Release
 
     protected $description = 'Branch all modules';
 
+    /**
+     * Will branch to minor version (e.g. 1.1) for all stable releases only
+     */
+    const AUTO = 'auto'; // Automatic branching
+
+    /**
+     * Auto description
+     */
+    const AUTO_DESCRIPTION = 'Uses <info>minor</info> for stable tags, <info>none</info> for unstable tags';
+
+    /**
+     * Branch to major version (e.g. 1) unless already on specific minor branch
+     */
+    const MAJOR = 'major';
+
+    /**
+     * Major description
+     */
+    const MAJOR_DESCRIPTION = 'Branch to major version (e.g. 1) unless already on specific minor branch';
+
+    /**
+     * Branch to minor version (E.g. 1.1)
+     */
+    const MINOR = 'minor';
+
+    /**
+     * Minor description
+     */
+    const MINOR_DESCRIPTION = 'Branch to minor version (E.g. 1.1)';
+
+    /**
+     * No branching will occur
+     */
+    const NONE = 'none';
+
+    /**
+     * None description
+     */
+    const NONE_DESCRIPTION = 'No branching will occur';
+
+    /**
+     * List of valid options
+     */
+    const OPTIONS = [
+        self::AUTO => self::AUTO_DESCRIPTION,
+        self::MAJOR => self::MAJOR_DESCRIPTION,
+        self::MINOR => self::MINOR_DESCRIPTION,
+        self::NONE => self::NONE_DESCRIPTION,
+    ];
+
+    /**
+     * Default branch option
+     */
+    const DEFAULT_OPTION = self::AUTO;
+
     protected function fire()
     {
         // Get arguments
         $version = $this->getInputVersion();
         $project = $this->getProject();
+        $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -25,9 +25,10 @@ class Changelog extends Release
         // Get arguments
         $version = $this->getInputVersion();
         $project = $this->getProject();
+        $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Commands/Release/Plan.php
+++ b/src/Commands/Release/Plan.php
@@ -19,9 +19,10 @@ class Plan extends Release
         // Get arguments
         $version = $this->getInputVersion();
         $project = $this->getProject();
+        $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching);
         $buildPlan->run($this->input, $this->output);
     }
 }

--- a/src/Commands/Release/Translate.php
+++ b/src/Commands/Release/Translate.php
@@ -21,9 +21,10 @@ class Translate extends Release
         // Get arguments
         $version = $this->getInputVersion();
         $project = $this->getProject();
+        $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -966,6 +966,12 @@ class Library
             if (!empty($data['Items'])) {
                 $libraryRelease->addItems($this->unserialisePlan($data['Items']));
             }
+
+            // Set branching
+            if (!empty($data['Branching'])) {
+                $libraryRelease->setBranching($data['Branching']);
+            }
+
             $releases[$name] = $libraryRelease;
         }
         return $releases;
@@ -984,7 +990,8 @@ class Library
         $content[$name] = [
             'Version' => $plan->getVersion()->getValue(),
             'Changelog' => $plan->getChangelog(),
-            'Items' => []
+            'Items' => [],
+            'Branching' => $plan->getBranching(null), // Only store internal value don't failover
         ];
         foreach ($plan->getItems() as $item) {
             $content[$name]['Items'] = array_merge(

--- a/src/Model/Modules/Module.php
+++ b/src/Model/Modules/Module.php
@@ -89,6 +89,21 @@ class Module extends Library
     }
 
     /**
+     * Get parameter to pass to i18n text collector
+     *
+     * @return string
+     */
+    public function getI18nTextCollectorName()
+    {
+        $dir = $this->getRelativeMainDirectory();
+        // If short name has any slashes just use composer name instead
+        if (preg_match('#\w[\\/]\w#', $dir)) {
+            return $this->getName();
+        }
+        return $dir;
+    }
+
+    /**
      * Determine if this project has a .tx configured
      *
      * @return bool

--- a/src/Model/Modules/Project.php
+++ b/src/Model/Modules/Project.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Cow\Model\Modules;
 
+use BadMethodCallException;
 use Generator;
 use InvalidArgumentException;
 
@@ -109,5 +110,25 @@ class Project extends Module
     public function getProject()
     {
         return $this;
+    }
+
+    /**
+     * Get path to sake executable
+     *
+     * @return string
+     */
+    public function getSakePath()
+    {
+        $candidates = [
+            $this->getDirectory() . '/vendor/bin/sake', // New standard location
+            $this->getDirectory() . '/vendor/silverstripe/framework/sake',
+            $this->getDirectory() . '/framework/sake',
+        ];
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
+        throw new BadMethodCallException("sake bin could not be found in this project");
     }
 }

--- a/src/Model/Release/LibraryRelease.php
+++ b/src/Model/Release/LibraryRelease.php
@@ -4,6 +4,7 @@
 namespace SilverStripe\Cow\Model\Release;
 
 use Generator;
+use SilverStripe\Cow\Commands\Release\Branch;
 use SilverStripe\Cow\Model\Modules\Library;
 
 /**
@@ -17,6 +18,13 @@ class LibraryRelease
      * @var LibraryRelease[]
      */
     protected $items = [];
+
+    /**
+     * Default branching strategy (only valid on root release)
+     *
+     * @var string
+     */
+    protected $branching = null;
 
     /**
      * The module being released
@@ -228,6 +236,29 @@ class LibraryRelease
     public function setChangelog($changelog)
     {
         $this->changelog = $changelog;
+        return $this;
+    }
+
+    /**
+     * Get branching strategy
+     *
+     * @param string $default Default value to get if no value found
+     * @return string
+     */
+    public function getBranching($default = Branch::DEFAULT_OPTION)
+    {
+        return $this->branching ?: $default;
+    }
+
+    /**
+     * Set branching strategy
+     *
+     * @param string $branching
+     * @return $this
+     */
+    public function setBranching($branching)
+    {
+        $this->branching = $branching;
         return $this;
     }
 }

--- a/src/Model/Release/LibraryRelease.php
+++ b/src/Model/Release/LibraryRelease.php
@@ -245,7 +245,7 @@ class LibraryRelease
      * @param string $default Default value to get if no value found
      * @return string
      */
-    public function getBranching($default = Branch::DEFAULT_OPTION)
+    public function getBranching($default = Branch::AUTO)
     {
         return $this->branching ?: $default;
     }

--- a/src/Steps/Release/UpdateTranslations.php
+++ b/src/Steps/Release/UpdateTranslations.php
@@ -279,12 +279,13 @@ class UpdateTranslations extends ReleaseStep
         // Get code dirs for each module
         $dirs = array();
         foreach ($modules as $module) {
-            $dirs[] = $module->getRelativeMainDirectory();
+            $dirs[] = $module->getI18nTextCollectorName();
         }
 
         $sakeCommand = sprintf(
-            '(cd %s && ./framework/sake dev/tasks/i18nTextCollectorTask "flush=all" "merge=1" "module=%s")',
+            '(cd %s && %s dev/tasks/i18nTextCollectorTask "flush=all" "merge=1" "module=%s")',
             $this->getProject()->getDirectory(),
+            $this->getProject()->getSakePath(),
             implode(',', $dirs)
         );
         $this->runCommand($output, $sakeCommand, "Error encountered running i18nTextCollectorTask");

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -20,6 +20,14 @@ abstract class Step
      */
     protected $command;
 
+    /**
+     * Default env vars to set
+     * @var array
+     */
+    protected $envs = [
+        'SS_VENDOR_METHOD' => 'copy', // Ensure that vendor copies, rather than symlinks, assets
+    ];
+
     public function __construct(Command $command)
     {
         $this->setCommand($command);
@@ -107,6 +115,10 @@ abstract class Step
         } else {
             $process = new Process($command);
         }
+
+        // Set all default env vars
+        $process->inheritEnvironmentVariables();
+        $process->setEnv($this->envs);
 
         // Run it
         $process->setTimeout(null);


### PR DESCRIPTION
Rebased on top of https://github.com/silverstripe/cow/pull/57

Fixes #53 

You can specify branching via a `--branching` option, which is saved into the release plan. You can also modify this value at the planning stage.

![image](https://user-images.githubusercontent.com/936064/31421996-67e856b0-aea7-11e7-8fa5-9d465fedfad1.png)
