### PR TITLE
FIX Regression in child-stability-inherit: accepts boolean or array of strings

### DIFF
--- a/cow-schema.md
+++ b/cow-schema.md
@@ -13,7 +13,7 @@ Basic options are:
 * `changelog-github` (bool) Push up changelog to github up via github release API (v3)
 * `changelog-format` Either 'flat' (single list of items) or 'grouped' (grouped by standard groups).\
   Defaults to 'grouped' if left out.
-* `child-stability-inherit` (bool) If set to true, child modules will be released with the same stability
+* `child-stability-inherit` (bool|array) If set to true, child modules will be released with the same stability
   (e.g. -alpha1) as the parent. This can also be set to an array of modules to limit child stability inheritance to.
 * `vendors` Declare list of child requirement library vendors that will be released. A vendor must be declared,
   otherwise no child dependencies will be released.

--- a/cow.schema.json
+++ b/cow.schema.json
@@ -27,7 +27,17 @@
       "type": "boolean"
     },
     "child-stability-inherit": {
-      "type": "boolean"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "dependency-constraint": {
       "type": "string",


### PR DESCRIPTION
Fixes regression in child-stability-inherit, which should be an array of strings or a boolean.

Fixes #70