### PR TITLE
NEW Add schema:validate command and return command exit code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,3 +108,10 @@ each of which could be run separately.
 
 After the push step, `release:publish` will automatically wait for this version to be available in packagist.org
 before continuing.
+
+## Schema
+
+The [cow schema file](cow.schema.json) is in the root of this project.
+
+You can run `cow schema:validate` to check the `.cow.json` configuration file in your project or module to
+ensure it matches against the cow schema.

--- a/src/Application.php
+++ b/src/Application.php
@@ -69,6 +69,9 @@ class Application extends Console\Application
         // Module commands
         $commands[] = new Commands\Module\TranslateBuild();
 
+        // Schema commands
+        $commands[] = new Commands\Schema\Validate();
+
         return $commands;
     }
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -55,7 +55,7 @@ abstract class Command extends Console\Command\Command
         // Configure extra output formats
         $this->output->getFormatter()->setStyle('bold', new OutputFormatterStyle('blue'));
 
-        $this->fire();
+        return $this->fire();
     }
 
     /**

--- a/src/Commands/Schema/Validate.php
+++ b/src/Commands/Schema/Validate.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\Cow\Commands\Schema;
+
+use Exception;
+use JsonSchema\Validator;
+use SilverStripe\Cow\Commands\Command;
+use SilverStripe\Cow\Utility\Config;
+use SilverStripe\Cow\Utility\SchemaValidator;
+
+/**
+ * Validates the cow configuration file against the cow schema
+ */
+class Validate extends Command
+{
+    protected $name = 'schema:validate';
+
+    protected $description = 'Validate the cow configuration file';
+
+    /**
+     * Get the contents of the cow configuration file in the current directory
+     *
+     * @return array
+     * @throws Exception
+     */
+    protected function getCowData()
+    {
+        $directory = getcwd();
+        $cowFile = $directory . '/.cow.json';
+        if (!file_exists($cowFile)) {
+            throw new Exception('.cow.json does not exist in current directory');
+        }
+
+        return Config::parseContent(file_get_contents($cowFile), false);
+    }
+
+    /**
+     * Validate the current directory's cow configuration file against the schema
+     *
+     * @return int Process exit code
+     * @throws Exception
+     */
+    protected function fire()
+    {
+        $cowData = $this->getCowData();
+
+        /** @var Validator $validator */
+        $validator = SchemaValidator::validate($cowData);
+
+        if ($validator->isValid()) {
+            $this->output->writeln('<info>Cow schema is valid!</info>');
+            return 0;
+        }
+
+        $this->output->writeln('<info>Cow schema failures:</info>');
+        foreach ($validator->getErrors() as $error) {
+            $this->output->writeln('<error>' . $error['property'] . ': ' . $error['message'] . '</error>');
+        }
+        return 1;
+    }
+
+    protected function configureOptions()
+    {
+        // noop
+    }
+}

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -15,6 +15,7 @@ use SilverStripe\Cow\Model\Release\LibraryRelease;
 use SilverStripe\Cow\Model\Release\Version;
 use SilverStripe\Cow\Utility\Config;
 use SilverStripe\Cow\Utility\Format;
+use SilverStripe\Cow\Utility\SchemaValidator;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -628,9 +629,8 @@ class Library
      */
     public function getCowData()
     {
-        // http://json-schema.org/examples.html
         $path = $this->getDirectory() . '/.cow.json';
-        $schemaPath = dirname(dirname(dirname(__DIR__))).'/cow.schema.json';
+        $schemaPath = dirname(dirname(dirname(__DIR__))) . '/' . SchemaValidator::SCHEMA_FILENAME;
         return Config::loadFromFile($path, $schemaPath);
     }
 

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Cow\Utility;
 
 use Exception;
-use JsonSchema\Validator;
 
 class Config
 {
@@ -27,9 +26,10 @@ class Config
         if ($schemaPath) {
             // Note: Parse as object (assoc = false) for validation
             $schema = static::loadFromFile($schemaPath);
-            $validator = new Validator();
+
             $objectData = self::parseContent($content, false);
-            $validator->validate($objectData, $schema);
+            $validator = SchemaValidator::validate($objectData, $schema);
+
             if (!$validator->isValid()) {
                 $errors = [];
                 foreach ($validator->getErrors() as $error) {

--- a/src/Utility/SchemaValidator.php
+++ b/src/Utility/SchemaValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SilverStripe\Cow\Utility;
+
+use Exception;
+use JsonSchema\Validator;
+
+/**
+ * Validates input data against the cow schema file
+ */
+class SchemaValidator
+{
+    /**
+     * @var string
+     */
+    const SCHEMA_FILENAME = 'cow.schema.json';
+
+    /**
+     * Loads and return the cow schema
+     *
+     * @return array
+     * @throws Exception
+     */
+    public static function getSchema()
+    {
+        $schemaPath = dirname(dirname(__DIR__)) . '/' . self::SCHEMA_FILENAME;
+        return Config::loadFromFile($schemaPath);
+    }
+
+    /**
+     * Validate the incoming object data against the given schema. If no schema is provided then the default cow
+     * schema will be loaded.
+     *
+     * @param array $objectData
+     * @param array $schema If not provided, the default will be used
+     * @return Validator
+     */
+    public static function validate($objectData, $schema = null)
+    {
+        if (is_null($schema)) {
+            $schema = self::getSchema();
+        }
+
+        $validator = new Validator();
+        $validator->validate($objectData, $schema);
+
+        return $validator;
+    }
+}

--- a/tests/Utility/SchemaValidatorTest.php
+++ b/tests/Utility/SchemaValidatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Utility;
+
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Utility\SchemaValidator;
+
+class SchemaValidatorTest extends PHPUnit_Framework_TestCase
+{
+    protected $cowSchema;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cowSchema = file_get_contents(dirname(dirname(__DIR__)) . '/cow.schema.json');
+    }
+
+    public function testValidSchema()
+    {
+        $cowConfig = <<<JSON
+{
+  "child-stability-inherit": [
+    "cwp/cwp",
+    "cwp/cwp-core"
+  ],
+  "upgrade-only": [
+    "silverstripe/cms",
+    "silverstripe/framework",
+    "silverstripe/siteconfig",
+    "silverstripe/reports",
+    "symbiote/silverstripe-gridfieldextensions"
+  ],
+  "vendors": [
+    "cwp",
+    "silverstripe",
+    "symbiote"
+  ]
+}
+JSON;
+
+        $validator = SchemaValidator::validate(json_decode($cowConfig));
+
+        $this->assertTrue($validator->isValid());
+    }
+
+    public function testInvalidSchema()
+    {
+        $cowConfig = <<<JSON
+{
+  "vendors": "all-the-things"
+}
+JSON;
+
+        $validator = SchemaValidator::validate(json_decode($cowConfig));
+
+        $this->assertFalse($validator->isValid());
+    }
+}


### PR DESCRIPTION
This pull request adds a SchemaValidator utility class and adds a new `schema:validate` command.

Also now returning the exit code from Command to ensure we can check for schema validation failures via exit code 1 in CI builds (when this command makes it into CI!).

Resolves #68 