### PR TITLE
FIX stop autoload failure on case sensitive system

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -54,7 +54,7 @@ class Application extends Console\Application
         $commands[] = new Commands\Release\Branch();
         $commands[] = new Commands\Release\Translate();
         $commands[] = new Commands\Release\Test();
-        $commands[] = new Commands\Release\ChangeLog();
+        $commands[] = new Commands\Release\Changelog();
 
         // Publish sub-commands
         $commands[] = new Commands\Release\Tag();


### PR DESCRIPTION
Trying to install and run cow on an Ubuntu system I was greeted by a fatal error "can't find class ChangeLog" - which was caused by the differences between the class name call of `ChangeLog` and the class name (and thus filename) being `Changelog.php`. Correcting this single erroneous reference has fixed the issue.