### PR TITLE
FIX order of arguments to git-pull is important

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -357,7 +357,7 @@ class Library
 
         // Pull
         try {
-            $repo->run('pull', [$remote, $branch, '--rebase']);
+            $repo->run('pull', ['--rebase', $remote, $branch]);
         } finally {
             // Restore locale changes
             if ($hasChanges) {


### PR DESCRIPTION
`git pull origin master --rebase` causes an error with unknown option 'rebase', however it _is_ a thing, but it must be specified as `git pull --rebase origin master`, so update `cow` to use this syntax instead.