### PR TITLE
FIX Use correct repository path for .cow.repository writing

### DIFF
--- a/src/Steps/Release/CreateProject.php
+++ b/src/Steps/Release/CreateProject.php
@@ -93,8 +93,8 @@ class CreateProject extends Step
         }
 
         // If using custom repository, write `.cow.repository` file for later
-        if ($this->getRepository()) {
-            file_put_contents($path.'/.cow.repository', $this->getRepository());
+        if ($repo) {
+            file_put_contents($repo->getPath() . '/.cow.repository', $this->getRepository());
         }
 
         // Success


### PR DESCRIPTION
Fixes issue when using a custom repository during `cow release:create`:

```
[create project] Reverting installer changes to composer.json
PHP Warning:  file_put_contents(.../dev/releases/release-silverstripe_installer-1.2.3/composer.json/.cow.repository): failed to open stream: No such file or directory in .../.composer/vendor/silverstripe/cow/src/Steps/Release/CreateProject.php on line 97
```