### PR TITLE
NEW Add --skip-fetch-tags option to skip fetching tags from origin during plan creation

### DIFF
--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -46,6 +46,12 @@ class Release extends Command
                 'Skip the text collection task when performing the release'
             )
             ->addOption(
+                'skip-fetch-tags',
+                null,
+                InputOption::VALUE_NONE,
+                'Skip fetching tags from origin'
+            )
+            ->addOption(
                 'branching',
                 'b',
                 InputOption::VALUE_REQUIRED,
@@ -192,7 +198,12 @@ class Release extends Command
     protected function getProject()
     {
         $directory = $this->getInputDirectory();
-        return new Project($directory);
+        $project = new Project($directory);
+
+        $fetchTags = !$this->input->getOption('skip-fetch-tags');
+        $project->setFetchTags($fetchTags);
+
+        return $project;
     }
 
     /**

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -263,7 +263,10 @@ class Library
 
         // Get tag strings
         $repo = $this->getRepository();
-        $repo->run('fetch', ['--tags']);
+        if ($this->getProject()->getFetchTags()) {
+            // Fetch remote tags from origin first
+            $repo->run('fetch', ['--tags']);
+        }
         $result = $repo->run('tag');
         $tags = preg_split('~\R~u', $result);
         $tags = array_filter($tags);

--- a/src/Model/Modules/Project.php
+++ b/src/Model/Modules/Project.php
@@ -26,6 +26,13 @@ class Project extends Module
      */
     protected $modulePaths = null;
 
+    /**
+     * Whether to fetch tags during plan generation
+     *
+     * @var bool
+     */
+    protected $fetchTags = true;
+
     public function __construct($directory)
     {
         parent::__construct($directory);
@@ -166,6 +173,28 @@ class Project extends Module
         // Register and return
         $this->libraries[$name] = $library;
         return $library;
+    }
+
+    /**
+     * Set whether to fetch tags during plan generation
+     *
+     * @param bool $fetchTags
+     * @return $this
+     */
+    public function setFetchTags($fetchTags)
+    {
+        $this->fetchTags = (bool) $fetchTags;
+        return $this;
+    }
+
+    /**
+     * Whether to fetch tags during plan generation
+     *
+     * @return bool
+     */
+    public function getFetchTags()
+    {
+        return $this->fetchTags;
     }
 
     /**

--- a/src/Steps/Release/CreateProject.php
+++ b/src/Steps/Release/CreateProject.php
@@ -84,6 +84,9 @@ class CreateProject extends Step
 
         // Revert composer / recipe-core changes to composer.json
         $library = $this->getProject();
+        $fetchTags = !$input->getOption('skip-fetch-tags');
+        $library->setFetchTags($fetchTags);
+
         $path = $library->getComposerPath();
         $repo = $library->getRepository();
         $status = $repo->run("status", [$path]);


### PR DESCRIPTION
After you've initially created the plan you don't really need to keep fetching tags each time.

It's important that it defaults to doing so when you are first creating the plan, but after that it doesn't need to.

You may also not want to fetch tags during plan generation if you're just tweaking a couple of versions.

This PR adds a `--skip-fetch-tags` option which will do that.

Resolves #77 