### PR TITLE
NEW Make sure cow outputs the correct bin name when giving commands

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -31,6 +31,15 @@ class Application extends Console\Application
         return $this->getVersionInDir(dirname($directory));
     }
 
+    /**
+     * Get the name of the application used to run the command, eg: cow or bin/cow
+     *
+     * @return string
+     */
+    public function getBinName()
+    {
+        return isset($_SERVER['argv'][0]) ? $_SERVER['argv'][0] : 'cow';
+    }
 
     public function getLongVersion()
     {

--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -218,7 +218,8 @@ class Release extends Command
      */
     protected function getPublishCommand($version, $project)
     {
-        $command = 'cow release:publish ' . $version->getValue() . ' ' . $project->getName();
+        $binName = $this->getApplication()->getBinName();
+        $command = $binName . ' release:publish ' . $version->getValue() . ' ' . $project->getName();
         switch ($this->output->getVerbosity()) {
             case Output::VERBOSITY_DEBUG:
                 $command .= ' -vvv';


### PR DESCRIPTION
At the moment the recommended next command when finishing `cow release` always shows to run `cow release:tag` even if you're running cow via some other path.

This fixes that.