### PR TITLE
FIX Dont use --ignore-platform-reqs

### DIFF
--- a/src/Steps/Release/BuildArchive.php
+++ b/src/Steps/Release/BuildArchive.php
@@ -172,7 +172,7 @@ class BuildArchive extends ReleaseStep
 
         // Install to this location
         $this->log($output, "Installing version {$version}");
-        Composer::createProject($this->getCommandRunner($output), $name, $path, $version, $this->getRepository(), true);
+        Composer::createProject($this->getCommandRunner($output), $name, $path, $version, $this->getRepository());
 
         // Copy composer.phar to the project
         // Write version info to the core folders (shouldn't be in version control)

--- a/src/Utility/Composer.php
+++ b/src/Utility/Composer.php
@@ -47,8 +47,15 @@ class Composer
         $preferDist = false,
         $ignorePlatform = false
     ) {
+        if ($ignorePlatform !== false) {
+            user_error(
+                '$ingorePlatform argument is now deprecated, set up the correct platform via composer config',
+                E_USER_DEPRECATED
+            );
+        }
+
         // Create comand
-        $createOptions = self::getCreateOptions($repository, $preferDist, $ignorePlatform);
+        $createOptions = self::getCreateOptions($repository, $preferDist);
         $runner->runCommand(array_merge([
             "composer",
             "create-project",
@@ -68,7 +75,7 @@ class Composer
         }
 
         // Update with the given repository
-        $updateOptions = self::getUpdateOptions($preferDist, $ignorePlatform);
+        $updateOptions = self::getUpdateOptions($preferDist);
         $runner->runCommand(array_merge([
             'composer',
             'update',
@@ -141,7 +148,7 @@ class Composer
      * @param bool $ignorePlatform
      * @return array
      */
-    protected static function getCreateOptions($repository, $preferDist, $ignorePlatform)
+    protected static function getCreateOptions($repository, $preferDist, $ignorePlatform = null)
     {
         // Create-options
         $createOptions = [
@@ -150,9 +157,11 @@ class Composer
             '--no-install',
         ];
 
-        // Set ignore platform reqs
-        if ($ignorePlatform) {
-            $createOptions[] = '--ignore-platform-reqs';
+        if ($ignorePlatform !== null) {
+            user_error(
+                '$ingorePlatform argument is now deprecated, set up the correct platform via composer config',
+                E_USER_DEPRECATED
+            );
         }
 
         // Set dev / stable options
@@ -179,14 +188,16 @@ class Composer
      * @param bool $ignorePlatform
      * @return array
      */
-    protected static function getUpdateOptions($preferDist, $ignorePlatform)
+    protected static function getUpdateOptions($preferDist, $ignorePlatform = null)
     {
         // update options
         $updateOptions = [ "--no-interaction" ];
 
-        // Set ignore platform reqs
-        if ($ignorePlatform) {
-            $updateOptions[] = '--ignore-platform-reqs';
+        if ($ignorePlatform !== null) {
+            user_error(
+                '$ingorePlatform argument is now deprecated, set up the correct platform via composer config',
+                E_USER_DEPRECATED
+            );
         }
 
         // Set dev / stable options


### PR DESCRIPTION
We should never use `--ignore-platform-reqs` with composer. Whilst it appeared to be helpful at the time it's actually making things worse.

Cow needs to define the platform using [`composer config`](https://getcomposer.org/doc/06-config.md#platform) rather than outright ignoring the platform (which is effectively an `--install-highest` flag).

The killer problem with `--ignore-platform-reqs` is that even if we use `composer config` to define the platform (hint: we do) the flag means composer ignores that *as well as* our actual platform constraints.

All in all, it results in creating archives which only run on the highest of all our valid dependencies (PHP 7.2) rather than the lowest (5.6.0)

tl;dr `--ignore-platform-reqs` is evil, we must destroy it