### PR TITLE
NEW Add --all-commits option for changelog generation to categorise "Other changes"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=5.6",
     "symfony/console": "^3.2",
     "symfony/process": "^3.2",
     "symfony/yaml": "^3.2",

--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,22 @@ each of which could be run separately.
 After the push step, `release:publish` will automatically wait for this version to be available in packagist.org
 before continuing.
 
+## Creating changelogs
+
+`cow release:changelog` will create a changelog which is categorised into various sets of change types, e.g.
+enhancements, bug fixes, API changes and security fixes.
+
+The changelog command takes the follow arguments and options:
+
+* `version` The version you're releasing the project as
+* `recipe` The recipe you're releasing
+* `--include-other-changes` If provided, uncategorised commits will also be included in an "Other changes" section.
+  Note that commits which match `ChangelogItem::isIgnored()` will still be excluded, e.g. merge commits.
+
+**Pro-tip:** Part of this command involves plan generation and/or confirmation, and you can provide the
+`--skip-fetch-tags` option to prevent Cow from re-fetching all tags from origin if you have already done this
+and only want to make a quick change.
+
 ## Schema
 
 The [cow schema file](cow.schema.json) is in the root of this project.

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -26,10 +26,10 @@ class Changelog extends Release
         parent::configureOptions();
 
         $this->addOption(
-            'all-commits',
+            'include-other-changes',
             null,
             InputOption::VALUE_NONE,
-            'Include all changes in the changelog (default: false)'
+            'Include other changes in the changelog (default: false)'
         );
     }
 
@@ -55,8 +55,8 @@ class Changelog extends Release
      *
      * @return bool
      */
-    public function getIncludeAllCommits()
+    public function getIncludeOtherChanges()
     {
-        return (bool) $this->input->getOption('all-commits');
+        return (bool) $this->input->getOption('include-other-changes');
     }
 }

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Cow\Commands\Release;
 
 use SilverStripe\Cow\Steps\Release\CreateChangelog;
 use SilverStripe\Cow\Steps\Release\PlanRelease;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Description of Create
@@ -20,6 +21,18 @@ class Changelog extends Release
 
     protected $description = 'Generate changelog';
 
+    protected function configureOptions()
+    {
+        parent::configureOptions();
+
+        $this->addOption(
+            'all-commits',
+            null,
+            InputOption::VALUE_NONE,
+            'Include all changes in the changelog (default: false)'
+        );
+    }
+
     protected function fire()
     {
         // Get arguments
@@ -33,7 +46,17 @@ class Changelog extends Release
         $releasePlan = $buildPlan->getReleasePlan();
 
         // Generate changelog
-        $changelogs = new CreateChangelog($this, $project, $releasePlan);
-        $changelogs->run($this->input, $this->output);
+        $changelog = new CreateChangelog($this, $project, $releasePlan);
+        $changelog->run($this->input, $this->output);
+    }
+
+    /**
+     * Whether to include all commits in the changelog
+     *
+     * @return bool
+     */
+    public function getIncludeAllCommits()
+    {
+        return (bool) $this->input->getOption('all-commits');
     }
 }

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -13,25 +13,9 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class Changelog extends Release
 {
-    /**
-     *
-     * @var string
-     */
     protected $name = 'release:changelog';
 
     protected $description = 'Generate changelog';
-
-    protected function configureOptions()
-    {
-        parent::configureOptions();
-
-        $this->addOption(
-            'include-other-changes',
-            null,
-            InputOption::VALUE_NONE,
-            'Include other changes in the changelog (default: false)'
-        );
-    }
 
     protected function fire()
     {
@@ -48,15 +32,5 @@ class Changelog extends Release
         // Generate changelog
         $changelog = new CreateChangelog($this, $project, $releasePlan);
         $changelog->run($this->input, $this->output);
-    }
-
-    /**
-     * Whether to include all commits in the changelog
-     *
-     * @return bool
-     */
-    public function getIncludeOtherChanges()
-    {
-        return (bool) $this->input->getOption('include-other-changes');
     }
 }

--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -56,6 +56,12 @@ class Release extends Command
                 'b',
                 InputOption::VALUE_REQUIRED,
                 "Branching strategy. One of [{$branchOptions}]"
+            )
+            ->addOption(
+                'include-other-changes',
+                null,
+                InputOption::VALUE_NONE,
+                'Include other changes in the changelog (default: false)'
             );
     }
 
@@ -243,5 +249,15 @@ class Release extends Command
                 break;
         }
         return $command;
+    }
+
+    /**
+     * Whether to include all commits in the changelog
+     *
+     * @return bool
+     */
+    public function getIncludeOtherChanges()
+    {
+        return (bool) $this->input->getOption('include-other-changes');
     }
 }

--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -27,22 +27,9 @@ class Changelog
     protected $rootLibrary;
 
     /**
-     * @return ChangelogLibrary
+     * @var bool
      */
-    public function getRootLibrary()
-    {
-        return $this->rootLibrary;
-    }
-
-    /**
-     * @param ChangelogLibrary $rootLibrary
-     * @return $this
-     */
-    public function setRootLibrary($rootLibrary)
-    {
-        $this->rootLibrary = $rootLibrary;
-        return $this;
-    }
+    protected $includeAllCommits = false;
 
     /**
      * Create a new changelog
@@ -79,7 +66,7 @@ class Changelog
                 ->getLog($range);
 
             foreach ($log->getCommits() as $commit) {
-                $change = new ChangelogItem($changelogLibrary, $commit);
+                $change = new ChangelogItem($changelogLibrary, $commit, $this->getIncludeAllCommits());
 
                 // Detect duplicates and skip ignored items
                 $key = $change->getDistinctDetails();
@@ -295,5 +282,41 @@ class Changelog
             }
         });
         return $commits;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIncludeAllCommits()
+    {
+        return $this->includeAllCommits;
+    }
+
+    /**
+     * @param bool $includeAllCommits
+     * @return $this
+     */
+    public function setIncludeAllCommits($includeAllCommits)
+    {
+        $this->includeAllCommits = (bool) $includeAllCommits;
+        return $this;
+    }
+
+    /**
+     * @return ChangelogLibrary
+     */
+    public function getRootLibrary()
+    {
+        return $this->rootLibrary;
+    }
+
+    /**
+     * @param ChangelogLibrary $rootLibrary
+     * @return $this
+     */
+    public function setRootLibrary($rootLibrary)
+    {
+        $this->rootLibrary = $rootLibrary;
+        return $this;
     }
 }

--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -29,7 +29,7 @@ class Changelog
     /**
      * @var bool
      */
-    protected $includeAllCommits = false;
+    protected $includeOtherChanges = false;
 
     /**
      * Create a new changelog
@@ -66,7 +66,7 @@ class Changelog
                 ->getLog($range);
 
             foreach ($log->getCommits() as $commit) {
-                $change = new ChangelogItem($changelogLibrary, $commit, $this->getIncludeAllCommits());
+                $change = new ChangelogItem($changelogLibrary, $commit, $this->getIncludeOtherChanges());
 
                 // Detect duplicates and skip ignored items
                 $key = $change->getDistinctDetails();
@@ -287,18 +287,18 @@ class Changelog
     /**
      * @return bool
      */
-    public function getIncludeAllCommits()
+    public function getIncludeOtherChanges()
     {
-        return $this->includeAllCommits;
+        return $this->includeOtherChanges;
     }
 
     /**
-     * @param bool $includeAllCommits
+     * @param bool $includeOtherChanges
      * @return $this
      */
-    public function setIncludeAllCommits($includeAllCommits)
+    public function setIncludeOtherChanges($includeOtherChanges)
     {
-        $this->includeAllCommits = (bool) $includeAllCommits;
+        $this->includeOtherChanges = (bool) $includeOtherChanges;
         return $this;
     }
 

--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Cow\Model\Changelog;
 
-use Generator;
 use Gitonomy\Git\Exception\ReferenceNotFoundException;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -19,27 +19,14 @@ class ChangelogItem
     protected $changelogLibrary;
 
     /**
-     * @return ChangelogLibrary
-     */
-    public function getChangelogLibrary()
-    {
-        return $this->changelogLibrary;
-    }
-
-    /**
-     * @param ChangelogLibrary $changelogLibrary
-     * @return $this
-     */
-    public function setChangelogLibrary($changelogLibrary)
-    {
-        $this->changelogLibrary = $changelogLibrary;
-        return $this;
-    }
-
-    /**
      * @var Commit
      */
     protected $commit;
+
+    /**
+     * @var bool
+     */
+    protected $includeAllCommits = false;
 
     /**
      * Rules for ignoring commits
@@ -99,10 +86,11 @@ class ChangelogItem
      * @param ChangelogLibrary $changelogLibrary
      * @param Commit $commit
      */
-    public function __construct(ChangelogLibrary $changelogLibrary, Commit $commit)
+    public function __construct(ChangelogLibrary $changelogLibrary, Commit $commit, $includeAllCommits = false)
     {
         $this->setChangelogLibrary($changelogLibrary);
         $this->setCommit($commit);
+        $this->setIncludeAllCommits($includeAllCommits);
     }
 
     /**
@@ -246,9 +234,14 @@ class ChangelogItem
             }
         }
 
-        // Fallback check for CVE (not at start of string)
+        // Check for security identifier (not at start of string)
         if ($this->getSecurityCVE()) {
             return 'Security';
+        }
+
+        // Fallback check to see if we should include all commits
+        if ($this->getIncludeAllCommits()) {
+            return 'Other changes';
         }
 
         return null;
@@ -277,9 +270,9 @@ class ChangelogItem
     }
 
     /**
-     * If this is a security fix, get the CVP (in 'ss-2015-016' fomat)
+     * If this is a security fix, get the CVE/identifier (in 'ss-2015-016' format)
      *
-     * @return string|null cvp, or null if not
+     * @return string|null CVE/identifier, or null if not
      */
     public function getSecurityCVE()
     {
@@ -323,5 +316,41 @@ class ChangelogItem
         }
 
         return $content . "\n";
+    }
+
+    /**
+     * @return ChangelogLibrary
+     */
+    public function getChangelogLibrary()
+    {
+        return $this->changelogLibrary;
+    }
+
+    /**
+     * @param ChangelogLibrary $changelogLibrary
+     * @return $this
+     */
+    public function setChangelogLibrary($changelogLibrary)
+    {
+        $this->changelogLibrary = $changelogLibrary;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIncludeAllCommits()
+    {
+        return $this->includeAllCommits;
+    }
+
+    /**
+     * @param bool $includeAllCommits
+     * @return $this
+     */
+    public function setIncludeAllCommits($includeAllCommits)
+    {
+        $this->includeAllCommits = (bool) $includeAllCommits;
+        return $this;
     }
 }

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -35,6 +35,8 @@ class ChangelogItem
      */
     protected $ignoreRules = array(
         '/^Merge/',
+        '/branch alias/',
+        '/^Added(.*)changelog$/',
         '/^Blocked revisions/',
         '/^Initialized merge tracking /',
         '/^Created (branches|tags)/',

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -26,7 +26,7 @@ class ChangelogItem
     /**
      * @var bool
      */
-    protected $includeAllCommits = false;
+    protected $includeOtherChanges = false;
 
     /**
      * Rules for ignoring commits
@@ -92,7 +92,7 @@ class ChangelogItem
     {
         $this->setChangelogLibrary($changelogLibrary);
         $this->setCommit($commit);
-        $this->setIncludeAllCommits($includeAllCommits);
+        $this->setIncludeOtherChanges($includeAllCommits);
     }
 
     /**
@@ -242,7 +242,7 @@ class ChangelogItem
         }
 
         // Fallback check to see if we should include all commits
-        if ($this->getIncludeAllCommits()) {
+        if ($this->getIncludeOtherChanges()) {
             return 'Other changes';
         }
 
@@ -341,18 +341,18 @@ class ChangelogItem
     /**
      * @return bool
      */
-    public function getIncludeAllCommits()
+    public function getIncludeOtherChanges()
     {
-        return $this->includeAllCommits;
+        return $this->includeOtherChanges;
     }
 
     /**
-     * @param bool $includeAllCommits
+     * @param bool $includeOtherChanges
      * @return $this
      */
-    public function setIncludeAllCommits($includeAllCommits)
+    public function setIncludeOtherChanges($includeOtherChanges)
     {
-        $this->includeAllCommits = (bool) $includeAllCommits;
+        $this->includeOtherChanges = (bool) $includeOtherChanges;
         return $this;
     }
 }

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -105,6 +105,10 @@ class CreateChangelog extends ReleaseStep
 
         // Generate markedown from plan
         $changelog = new Changelog($changelogLibrary);
+        /** @var \SilverStripe\Cow\Commands\Release\Changelog $command */
+        $command = $this->getCommand();
+        $changelog->setIncludeAllCommits($command->getIncludeAllCommits());
+
         $content = $changelog->getMarkdown($output, $release->getLibrary()->getChangelogFormat());
 
         // Store this changelog

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -107,7 +107,7 @@ class CreateChangelog extends ReleaseStep
         $changelog = new Changelog($changelogLibrary);
         /** @var \SilverStripe\Cow\Commands\Release\Changelog $command */
         $command = $this->getCommand();
-        $changelog->setIncludeAllCommits($command->getIncludeAllCommits());
+        $changelog->setIncludeOtherChanges($command->getIncludeOtherChanges());
 
         $content = $changelog->getMarkdown($output, $release->getLibrary()->getChangelogFormat());
 

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -79,4 +79,42 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
         ];
     }
+
+    /**
+     * @param string $message
+     * @param bool $expected
+     * @dataProvider ignoredMessageProvider
+     */
+    public function testIsIgnored($message, $expected)
+    {
+        $commit = $this->createMock(Commit::class);
+        $commit->expects($this->once())->method('getSubjectMessage')->willReturn($message);
+
+        $item = new ChangelogItem($this->library, $commit);
+        $this->assertSame($expected, $item->isIgnored());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function ignoredMessageProvider()
+    {
+        return [
+            ['Merge branch 1 into 2', true],
+            ['Merge remote tracking branch origin/foo into master', true],
+            ['Update branch alias', true],
+            ['Remove obsolete branch alias', true],
+            ['Added 1.2.3-rc1 changelog', true],
+            ['Blocked revisions blah', true],
+            ['Initialized merge tracking against x', true],
+            ['Created branches 1.2 and 1.3', true],
+            ['Created tags 1.2.3 and 1.3.0', true],
+            ['NOTFORMERGE Whoops, we merged it anyway', true],
+            ['', true],
+            ['Fix a bug somewhere', false],
+            ['API Changing something big', false],
+            ['NEW Enhancing something', false],
+            ['[SS-2047-123] Something serious', false],
+        ];
+    }
 }

--- a/tests/Model/ChangelogTest.php
+++ b/tests/Model/ChangelogTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Model;
+
+use DateTime;
+use Gitonomy\Git\Commit;
+use Gitonomy\Git\Log;
+use Gitonomy\Git\Repository;
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Model\Changelog\Changelog;
+use SilverStripe\Cow\Model\Changelog\ChangelogLibrary;
+use SilverStripe\Cow\Model\Modules\Library;
+use SilverStripe\Cow\Model\Release\LibraryRelease;
+use SilverStripe\Cow\Model\Release\Version;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ChangelogTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @var Changelog
+     */
+    protected $changelog;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->output = new NullOutput();
+
+        $log = $this->createMock(Log::class);
+
+        $repository = $this->createMock(Repository::class);
+        $repository->method('getLog')->willReturn($log);
+
+        $commits = [
+            new Commit($repository, sha1('foo'), [
+                'shortHash' => 'shortfoo',
+                'subjectMessage' => 'FIX Changed foo for bar',
+                'authorName' => 'Alex Atkins',
+                'authorDate' => new DateTime('2014-12-25 09:02:10'),
+            ]),
+            new Commit($repository, sha1('bar'), [
+                'shortHash' => 'shortbar',
+                'subjectMessage' => 'API Remove baz',
+                'authorName' => 'Ryan Reid',
+                'authorDate' => new DateTime('1990-05-02 04:20:00'),
+            ]),
+            new Commit($repository, sha1('baz'), [
+                'shortHash' => 'shortbaz',
+                'subjectMessage' => 'NEW Added foobar',
+                'authorName' => 'Leslie Lolcopter',
+                'authorDate' => new DateTime('2015-01-03 12:15:31'),
+            ]),
+            new Commit($repository, sha1('boo'), [
+                'shortHash' => 'shortboo',
+                'subjectMessage' => 'Some uncategorised commit',
+                'authorName' => 'Val Vulcan',
+                'authorDate' => new DateTime('2015-04-20 04:20:00'),
+            ]),
+            new Commit($repository, sha1('damn'), [
+                'shortHash' => 'shortdamn',
+                'subjectMessage' => '[SS-2015-123] Someone forgot the coffee!',
+                'authorName' => 'Charlie Charizard',
+                'authorDate' => new DateTime('2015-04-20 04:20:00'),
+            ]),
+            new Commit($repository, sha1('anotherdamn'), [
+                'subjectMessage' => '[SS-2015-123] Someone forgot the coffee!',
+                'authorName' => 'Charlie Charizard',
+                'authorDate' => new DateTime('2015-04-20 04:20:00'),
+            ]),
+        ];
+        $log->method('getCommits')->willReturn($commits);
+
+        $library = $this->createMock(Library::class);
+        $library->method('getTags')->willReturn(['0.1.0', '0.1.1', '0.5.0']);
+        $library->method('getRepository')->willReturn($repository);
+        $library->method('getCommitLink')->will($this->returnCallback(function ($argument) {
+            return 'http://example.com/' . $argument;
+        }));
+
+        $version = new Version('1.0.0');
+        $priorVersion = new Version('0.5.0');
+
+        $release = new LibraryRelease($library, $version);
+
+        $changelogLibrary = new ChangelogLibrary($release, $priorVersion);
+
+        $this->changelog = new Changelog($changelogLibrary);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown changelog format foobar
+     */
+    public function testGetMarkdownThrowsExceptionOnInvalidType()
+    {
+        $this->changelog->getMarkdown($this->output, 'foobar');
+    }
+
+    public function testGetMarkdownGroupedContainsHeadings()
+    {
+        $result = $this->changelog->getMarkdown($this->output, Changelog::FORMAT_GROUPED);
+
+        $this->assertContains('## Change Log', $result);
+        $this->assertContains('### Security', $result);
+        $this->assertContains('### Bugfixes', $result);
+        $this->assertContains('### Features and Enhancements', $result);
+        $this->assertContains('### API Changes', $result);
+    }
+
+    public function testGetMarkdownFlatDoesNotContainHeadings()
+    {
+        $result = $this->changelog->getMarkdown($this->output, Changelog::FORMAT_FLAT);
+
+        $this->assertNotContains('## Change Log', $result);
+        $this->assertNotContains('### Bugfixes', $result);
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsCommitDates($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('2014-12-25', $result, 'Alex\'s commit date');
+        $this->assertContains('1990-05-02', $result, 'Ryan\'s commit date');
+        $this->assertContains('2015-01-03', $result, 'Leslie\'s commit date');
+        $this->assertContains('2015-04-20', $result, 'Charlie\'s commit date');
+    }
+
+    /**
+     * Short and long hashes should be in the changelogs - short is what we show to the user, long is used
+     * in the URLs. Long hashes are checkes in testChangelogContainsLinkToCommitInRepository.
+     *
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsShortHashes($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('shortfoo', $result, 'Alex\'s short commit');
+        $this->assertContains('shortbar', $result, 'Ryan\'s short commit');
+        $this->assertContains('shortbaz', $result, 'Leslie\'s short commit');
+        $this->assertContains('shortdamn', $result, 'Charlie\'s short commit');
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsAuthorNames($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('Alex Atkins', $result);
+        $this->assertContains('Ryan Reid', $result);
+        $this->assertContains('Leslie Lolcopter', $result);
+        $this->assertContains('Charlie Charizard', $result);
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsCommitMessagesWithPrefixesStripped($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('Changed foo for bar', $result);
+        $this->assertNotContains('FIX Changed foo for bar', $result, 'Prefixes are stripped');
+        $this->assertContains('Remove baz', $result);
+        $this->assertNotContains('API Remove baz', $result, 'Prefixes are stripped');
+        $this->assertContains('Added foobar', $result);
+        $this->assertNotContains('NEW Added foobar', $result, 'Prefixes are stripped');
+        $this->assertContains('Someone forgot the coffee!', $result);
+        $this->assertNotContains('[SS-2015-123] Someone forgot the coffee!', $result, 'Prefixes are stripped');
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogDoesNotContainUncategorisedCommitsByDefault($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertNotContains('Some uncategorised commit', $result, 'Uncategorised are ignored by default');
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsLinkToCommitInRepository($type)
+    {
+        $this->changelog->setIncludeOtherChanges(true);
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('http://example.com/' . sha1('foo'), $result);
+    }
+
+    /**
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testChangelogContainsUncategorisedCommitsIfRequested($type)
+    {
+        $this->changelog->setIncludeOtherChanges(true);
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains('Some uncategorised commit', $result);
+        $this->assertContains('Val Vulcan', $result);
+        $this->assertContains('2015-04-20', $result);
+        $this->assertContains('http://example.com/' . sha1('damn'), $result);
+        $this->assertContains('shortboo', $result, 'Val\'s short commit');
+    }
+
+    /**
+     * See ChangelogItem::getDistinctDetails. This should prevent commits that are merged up from appearing
+     * in changelogs more than once.
+     *
+     * @param string $type
+     * @dataProvider changelogFormatProvider
+     */
+    public function testDuplicateMergeUpCommitsAreExcluded($type)
+    {
+        $result = $this->changelog->getMarkdown($this->output, $type);
+
+        $this->assertContains(sha1('damn'), $result, 'Latest commit is included');
+        $this->assertNotContains(sha1('anotherdamn'), $result, 'Duplicated commit is ignored');
+    }
+
+    /**
+     * @return array[]
+     */
+    public function changelogFormatProvider()
+    {
+        return [
+            [Changelog::FORMAT_GROUPED],
+            [Changelog::FORMAT_FLAT],
+        ];
+    }
+}


### PR DESCRIPTION
This will allow a CWP release to include all "other changes" in the changelog, for example:

```
* 2018-01-04 [afb33a9](https://github.com/symbiote/silverstripe-queuedjobs/commit/afb33a982c23dfb60a4fca2c1b52e8f58a5c8472) More SS4 cleanup (Daniel Hensby)
* 2017-02-14 [3dc2935](https://github.com/symbiote/silverstripe-queuedjobs/commit/3dc2935ee99361ddea7420c5fdfc3b8b353fdfaa) Add(queue) defaultJobs yml config for setting up a list of required jobs (Stephen McMahon)
```

The default behaviour will continue not to include these changes (since they aren't prefixed with a cow tag), but can optionally include them if needed.

Open to feedback, but if merged then resolves #88