### PR TITLE
NEW Cow plans can now specify prior versions of modules explicitly

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -1006,6 +1006,12 @@ class Library
             $version = new Version($data['Version']);
             $libraryRelease = new LibraryRelease($library, $version);
 
+            // Set the previous version if specified
+            if (!empty($data['PriorVersion'])) {
+                $priorVersion = new Version($data['PriorVersion']);
+                $libraryRelease->setPriorVersion($priorVersion);
+            }
+
             // Restore cached changelog
             if (!empty($data['Changelog'])) {
                 $libraryRelease->setChangelog($data['Changelog']);
@@ -1037,6 +1043,7 @@ class Library
         $content = [];
         $name = $plan->getLibrary()->getName();
         $content[$name] = [
+            'PriorVersion' => $plan->getPriorVersion(false),
             'Version' => $plan->getVersion()->getValue(),
             'Changelog' => $plan->getChangelog(),
             'Items' => [],

--- a/src/Model/Release/LibraryRelease.php
+++ b/src/Model/Release/LibraryRelease.php
@@ -41,42 +41,6 @@ class LibraryRelease
     protected $changelog;
 
     /**
-     * @return Library
-     */
-    public function getLibrary()
-    {
-        return $this->library;
-    }
-
-    /**
-     * @param Library $library
-     * @return $this
-     */
-    public function setLibrary($library)
-    {
-        $this->library = $library;
-        return $this;
-    }
-
-    /**
-     * @return Version
-     */
-    public function getVersion()
-    {
-        return $this->version;
-    }
-
-    /**
-     * @param Version $version
-     * @return $this
-     */
-    public function setVersion($version)
-    {
-        $this->version = $version;
-        return $this;
-    }
-
-    /**
      * The version being released
      *
      * @var Version
@@ -84,15 +48,26 @@ class LibraryRelease
     protected $version;
 
     /**
+     * The previous version of the module being released
+     *
+     * @var Version
+     */
+    protected $priorVersion;
+
+    /**
      * LibraryRelease constructor.
      *
      * @param Library $library
      * @param Version $version
+     * @param Version|null $priorVersion
      */
-    public function __construct(Library $library, Version $version)
+    public function __construct(Library $library, Version $version, Version $priorVersion = null)
     {
         $this->setLibrary($library);
         $this->setVersion($version);
+        if ($priorVersion) {
+            $this->setPriorVersion($priorVersion);
+        }
     }
 
     /**
@@ -213,12 +188,31 @@ class LibraryRelease
     /**
      * Determine "from" version for this version
      *
+     * @param bool $fallback Whether to fall back to guessing from tags
      * @return Version
      */
-    public function getPriorVersion()
+    public function getPriorVersion($fallback = true)
     {
+        // If it has been explicitly provided, or we shouldn't fall back to using tags, return the prop
+        if ($this->priorVersion || !$fallback) {
+            return $this->priorVersion;
+        }
+
+        // Otherwise, guess it from the constraint and existing tags
         $tags = $this->getLibrary()->getTags();
         return $this->getVersion()->getPriorVersionFromTags($tags);
+    }
+
+    /**
+     * Explicitly set the "from" version for this version
+     *
+     * @param Version $version
+     * @return $this
+     */
+    public function setPriorVersion(Version $version)
+    {
+        $this->priorVersion = $version;
+        return $this;
     }
 
     /**
@@ -259,6 +253,42 @@ class LibraryRelease
     public function setBranching($branching)
     {
         $this->branching = $branching;
+        return $this;
+    }
+
+    /**
+     * @return Library
+     */
+    public function getLibrary()
+    {
+        return $this->library;
+    }
+
+    /**
+     * @param Library $library
+     * @return $this
+     */
+    public function setLibrary($library)
+    {
+        $this->library = $library;
+        return $this;
+    }
+
+    /**
+     * @return Version
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param Version $version
+     * @return $this
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
         return $this;
     }
 }

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -171,6 +171,7 @@ class CreateChangelog extends ReleaseStep
         // have been re-arranged since the prior tag.
         $pastComposer = null;
         foreach ($newRelease->getAllItems() as $childNewRelease) {
+            /** LibraryRelease $childNewRelease */
             // Lazy-load historic composer content as needed
             if (!isset($pastComposer)) {
                 // Get flat composer history up to 6 levels deep
@@ -184,14 +185,24 @@ class CreateChangelog extends ReleaseStep
             if (empty($pastComposer['require'][$childReleaseName])) {
                 continue;
             }
-            $historicConstraintName = $pastComposer['require'][$childReleaseName];
 
-            // Get oldest existing tag that matches the given constraint as the "from" for changelog purposes.
-            $historicConstraint = new ComposerConstraint($historicConstraintName, $historicVersion, $childReleaseName);
-            $childHistoricVersion = $childNewRelease->getLibrary()->getOldestVersionMatching(
-                $historicConstraint,
-                $childNewRelease->getVersion()->isStable()
-            );
+            // Use an explicitly specified previous version
+            $childHistoricVersion = $childNewRelease->getPriorVersion(false);
+            if (!$childHistoricVersion) {
+                $historicConstraintName = $pastComposer['require'][$childReleaseName];
+
+                // Get oldest existing tag that matches the given constraint as the "from" for changelog purposes.
+                $historicConstraint = new ComposerConstraint(
+                    $historicConstraintName,
+                    $historicVersion,
+                    $childReleaseName
+                );
+                $childHistoricVersion = $childNewRelease->getLibrary()->getOldestVersionMatching(
+                    $historicConstraint,
+                    $childNewRelease->getVersion()->isStable()
+                );
+            }
+
             if (!$childHistoricVersion) {
                 throw new \LogicException(
                     "No historic version for library {$childReleaseName} matches constraint {$historicConstraintName}"

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -486,8 +486,7 @@ class PlanRelease extends Step
             $version = ' (<info>' . $node->getVersion()->getValue() . '</info>) new tag';
 
             // If releasing a new tag, show previous version
-            $tags = $node->getLibrary()->getTags();
-            $previous = $node->getVersion()->getPriorVersionFromTags($tags);
+            $previous = $node->getPriorVersion();
             if ($previous) {
                 $version .= ', prior version <comment>' . $previous->getValue() . '</comment>';
             }

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -422,6 +422,11 @@ class PlanRelease extends Step
             );
             $result = $this->getQuestionHelper()->ask($input, $output, $question);
 
+            // Nothing was entered (just enter pressed) so take user back to the plan
+            if ($result instanceof Version) {
+                return;
+            }
+
             // If version is invalid, show an error message
             if (!Version::parse($result)) {
                 $this->log(

--- a/tests/Model/Release/LibraryReleaseTest.php
+++ b/tests/Model/Release/LibraryReleaseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Model\Release;
+
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Model\Modules\Library;
+use SilverStripe\Cow\Model\Release\LibraryRelease;
+use SilverStripe\Cow\Model\Release\Version;
+
+class LibraryReleaseTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstructionSetsPriorVersion()
+    {
+        $library = $this->createMock(Library::class);
+        $version = new Version('1.2.3');
+        $priorVersion = new Version('1.1.0');
+
+        $release = new LibraryRelease($library, $version, $priorVersion);
+        $this->assertSame($priorVersion, $release->getPriorVersion());
+    }
+
+    public function testGetPriorVersionFromExistingTags()
+    {
+        $library = $this->createMock(Library::class);
+        $library->expects($this->once())->method('getTags');
+
+        $priorVersion = new Version('1.1.0');
+        $version = $this->createMock(Version::class);
+        $version->expects($this->once())->method('getPriorVersionFromTags')->willReturn($priorVersion);
+
+        $release = new LibraryRelease($library, $version);
+        $this->assertSame(
+            $priorVersion,
+            $release->getPriorVersion(true),
+            'Fallback to getting the prior version from current versions list of tags'
+        );
+    }
+}


### PR DESCRIPTION
This allows the `.cow.pat.json` as the MVP to provide the `PriorVersion` for a module. This will be used in the cow plan and changelog, rather than guessing it from existing tags and constraints.

~I'd like to build this into the plan interface as well, but this was the minimum we wanted in order to be able to tweak plans occasionally for now~ (done). Resolves #87