### PR TITLE
FIX Prevent infinite loops when looking for installed.json

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -16,7 +16,7 @@ class Application extends Console\Application
      */
     protected function getVersionInDir($directory)
     {
-        if (!$directory) {
+        if (!$directory || dirname($directory) === $directory) {
             return null;
         }
         $installed = $directory . '/vendor/composer/installed.json';


### PR DESCRIPTION
I've yet to figure out why, but on my Mac OS system `file_exists` will always return false. This results in an infinite loop because `dirname('/') === '/'`