### PR TITLE
FIX A nicer error when vendor/autoload.php isn't found

### DIFF
--- a/bin/cow
+++ b/bin/cow
@@ -24,7 +24,10 @@ foreach ($paths as $path) {
 }
 
 if (!$included) {
-    throw new RuntimeException("What is Composer? Is a food?");
+    $binName = isset($_SERVER['argv'][0]) ? $_SERVER['argv'][0] : 'cow';
+    fwrite(STDERR, "$binName was unable to locate the vendor/autoload.php file.\n");
+    fwrite(STDERR, "Please make sure you've installed the composer dependencies by running composer install\n");
+    exit(1);
 }
 
 $app = new SilverStripe\Cow\Application();


### PR DESCRIPTION
Throwing an Exception this early is really horrible as the console library hasn't booted and so raw output is written to the console as text. The output message also wasn't so helpful.

Old output on failure:

```
PHP Fatal error:  Uncaught RuntimeException: What is Composer? Is a food? in /Users/dhensby/projects/releases/cow/bin/cow:27
Stack trace:
#0 {main}
  thrown in /Users/dhensby/projects/releases/cow/bin/cow on line 27

Fatal error: Uncaught RuntimeException: What is Composer? Is a food? in /Users/dhensby/projects/releases/cow/bin/cow:27
Stack trace:
#0 {main}
  thrown in /Users/dhensby/projects/releases/cow/bin/cow on line 27
```

New output on failure:

```
cow was unable to locate the vendor/autoload.php file.
Please make sure you've installed the composer dependencies by running composer install
```