### PR TITLE
Dont keep looking for vendor/composer/installed.json once its found

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -27,8 +27,9 @@ class Application extends Console\Application
                     return $library['version'];
                 }
             }
+        } else {
+            return $this->getVersionInDir(dirname($directory));
         }
-        return $this->getVersionInDir(dirname($directory));
     }
 
     /**


### PR DESCRIPTION
Sometimes the installed.json file won't contain `silverstripe/cow` (specifically when you haven't installed globally).

We shouldn't continue to look for the file once it's been found.