### PR TITLE
FIX Regex rules are improved to not match commit prefixes in words

### DIFF
--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -253,7 +253,7 @@ class Changelog
     /**
      * Sort and filter this list of commits into a grouped array of commits
      *
-     * @param array $commits Flat list of commits
+     * @param ChangelogItem[] $commits Flat list of commits
      * @return array Nested list of commit categories, each of which is a list of commits in that category.
      * Empty categories are still returned
      */

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -69,18 +69,18 @@ class ChangelogItem
      */
     protected static $types = array(
         'Security' => array(
-            // E.g. "[ss-2015-016]: Security fix"
+            // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
             '/^(\[SS-2(\d){3}-(\d){3}\])\s?:?/i'
         ),
         'API Changes' => array(
-            '/^(APICHANGE|API-CHANGE|API CHANGE|API)\s?:?/i'
+            '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b/'
         ),
         'Features and Enhancements' => array(
-            '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\s?:?/i'
+            '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b/'
         ),
         'Bugfixes' => array(
-            '/^(BUGFIX|BUGFUX|BUG|FIX|FIXED|FIXING)\s?:?/i',
-            '/^(BUG FIX)\s?:?/i'
+            '/^(BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\s?:?\b/',
+            '/^(BUG FIX)\b/'
         )
     );
 
@@ -196,8 +196,10 @@ class ChangelogItem
     {
         $message = $this->getMessage();
 
-        // Strip categorisation tags (API, BUG FIX, etc)
         foreach (self::$types as $rules) {
+            // Strip categorisation tags (API, BUG FIX, etc) where they are uppercase. If they match but are
+            // lowercase then we'll include them in the commit message, e.g. "Fixing regex rules" as opposed to
+            // "FIX Regex rules now work"
             foreach ($rules as $rule) {
                 $message = trim(preg_replace($rule, '', $message));
             }
@@ -238,7 +240,8 @@ class ChangelogItem
         $message = $this->getRawMessage();
         foreach (self::$types as $type => $rules) {
             foreach ($rules as $rule) {
-                if (preg_match($rule, $message)) {
+                // Add case insensitivity modifier
+                if (preg_match($rule . 'i', $message)) {
                     return $type;
                 }
             }

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -79,8 +79,7 @@ class ChangelogItem
             '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b/'
         ),
         'Bugfixes' => array(
-            '/^(BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\s?:?\b/',
-            '/^(BUG FIX)\b/'
+            '/^(BUG FIX|BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\s?:?\b/',
         )
     );
 

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -70,16 +70,16 @@ class ChangelogItem
     protected static $types = array(
         'Security' => array(
             // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
-            '/^(\[SS-2(\d){3}-(\d){3}\])\s?:?/i'
+            '/^(\[SS-2(\d){3}-(\d){3}\]):?/i'
         ),
         'API Changes' => array(
-            '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b/'
+            '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b:?/'
         ),
         'Features and Enhancements' => array(
-            '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b/'
+            '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b:?/'
         ),
         'Bugfixes' => array(
-            '/^(BUG FIX|BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\s?:?\b/',
+            '/^(BUG FIX|BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\b:?/',
         )
     );
 

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -61,6 +61,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['BUG Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['BUG FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
+            ['FIX: Forgot colon', 'Forgot colon', 'Bugfixes'],
             ['Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['Fixing some regex rules', 'Fixing some regex rules', 'Bugfixes'],
             ['Fixing Behat', 'Fixing Behat', 'Bugfixes'],
@@ -74,6 +75,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['ENH Support goland PHP extension', 'Support goland PHP extension', 'Features and Enhancements'],
             ['[SS-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
             ['[ss-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
+            ['[SS-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
             ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
         ];
     }

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -59,6 +59,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['BUG Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
+            ['BUG FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['Fixing some regex rules', 'Fixing some regex rules', 'Bugfixes'],

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Model\Changelog;
+
+use Gitonomy\Git\Commit;
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Model\Changelog\ChangelogItem;
+use SilverStripe\Cow\Model\Changelog\ChangelogLibrary;
+
+class ChangelogItemTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ChangelogLibrary
+     */
+    protected $library;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->library = $this->getMockBuilder(ChangelogLibrary::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @param string $originalMessage
+     * @param string $processedMessage
+     * @param string $category
+     * @dataProvider messageProvider
+     */
+    public function testGetType($originalMessage, $processedMessage, $category)
+    {
+        $commit = $this->createMock(Commit::class);
+        $commit->expects($this->atLeastOnce())->method('getSubjectMessage')->willReturn($originalMessage);
+
+        $item = new ChangelogItem($this->library, $commit);
+        $this->assertSame($category, $item->getType());
+    }
+
+    /**
+     * @param string $originalMessage
+     * @param string $processedMessage
+     * @dataProvider messageProvider
+     */
+    public function testGetShortMessage($originalMessage, $processedMessage)
+    {
+        $commit = $this->createMock(Commit::class);
+        $commit->expects($this->once())->method('getSubjectMessage')->willReturn($originalMessage);
+
+        $item = new ChangelogItem($this->library, $commit);
+        $this->assertSame($processedMessage, $item->getShortMessage());
+    }
+
+    /**
+     * @return array[] Original message, expected message, category
+     */
+    public function messageProvider()
+    {
+        return [
+            ['BUG Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
+            ['FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
+            ['Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
+            ['Fixing some regex rules', 'Fixing some regex rules', 'Bugfixes'],
+            ['Fixing Behat', 'Fixing Behat', 'Bugfixes'],
+            ['Fix a typo in the docs', 'Fix a typo in the docs', 'Bugfixes'],
+            ['Fixed a typo in the docs', 'Fixed a typo in the docs', 'Bugfixes'],
+            ['FIXed a typo in the docs', 'FIXed a typo in the docs', 'Bugfixes'],
+            ['FIX ed a typo in the docs', 'ed a typo in the docs', 'Bugfixes'],
+            ['API Remove DataObject', 'Remove DataObject', 'API Changes'],
+            ['API CHANGE Remove DataObject', 'Remove DataObject', 'API Changes'],
+            ['NEW Allow Python transpilation', 'Allow Python transpilation', 'Features and Enhancements'],
+            ['ENH Support goland PHP extension', 'Support goland PHP extension', 'Features and Enhancements'],
+            ['[SS-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
+            ['[ss-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
+            ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
+        ];
+    }
+}


### PR DESCRIPTION
For example, "Fixing foo" should not end up in the changelog as "ing foo", but FIX Fixing foo
should be  in the changelog as "Fixing foo"

Resolves #86