### PR TITLE
FIX PriorVersion value was not being saved to the cow plan

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -1036,14 +1036,15 @@ class Library
      * Serialise a plan to json
      *
      * @param LibraryRelease $plan
-     * @return array Encoded json data
+     * @return array Data to be later JSON encoded
      */
     public function serialisePlan(LibraryRelease $plan)
     {
         $content = [];
         $name = $plan->getLibrary()->getName();
+        $priorVersion = $plan->getPriorVersion(false);
         $content[$name] = [
-            'PriorVersion' => $plan->getPriorVersion(false),
+            'PriorVersion' => $priorVersion ? $priorVersion->getValue() : null,
             'Version' => $plan->getVersion()->getValue(),
             'Changelog' => $plan->getChangelog(),
             'Items' => [],

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -1033,7 +1033,8 @@ class Library
     }
 
     /**
-     * Serialise a plan to json
+     * Gather an array of data for the current plan (and sub-items), which will be encoded as JSON
+     * when written to file.
      *
      * @param LibraryRelease $plan
      * @return array Data to be later JSON encoded

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -424,6 +424,10 @@ class PlanRelease extends Step
 
             // Nothing was entered (just enter pressed) so take user back to the plan
             if ($result instanceof Version) {
+                // If pressing enter on prior version (optional), finish the loop but don't return
+                if ($key === 'prior_version') {
+                    continue;
+                }
                 return;
             }
 

--- a/tests/Model/Modules/LibraryTest.php
+++ b/tests/Model/Modules/LibraryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Model\Modules;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Model\Modules\Library;
+use SilverStripe\Cow\Model\Release\LibraryRelease;
+use SilverStripe\Cow\Model\Release\Version;
+
+class LibraryTest extends PHPUnit_Framework_TestCase
+{
+    public function testSerialisePlanSavesPriorVersion()
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $library */
+        $library = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getComposerData'])
+            ->getMock();
+
+        $library->expects($this->any())->method('getComposerData')->willReturn([
+            'name' => 'testrepo',
+        ]);
+
+        $version = new Version('1.2.3');
+        $priorVersion = new Version('1.1.0');
+        $plan = new LibraryRelease($library, $version, $priorVersion);
+
+        $result = $library->serialisePlan($plan);
+
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKey('testrepo', $result);
+        $this->assertSame('1.1.0', $result['testrepo']['PriorVersion']);
+    }
+}


### PR DESCRIPTION
The prior version value was not being correctly saved to the plan. This patch ensures that it does.

Fixes #116