### PR TITLE
Align composer config platform with requirements

### DIFF
--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -46,6 +46,12 @@ class Release extends Command
                 'Skip the text collection task when performing the release'
             )
             ->addOption(
+                'skip-emulate-requirements',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not emulate php and extension requirements through composer config platform'
+            )
+            ->addOption(
                 'skip-fetch-tags',
                 null,
                 InputOption::VALUE_NONE,

--- a/src/Steps/Release/BuildArchive.php
+++ b/src/Steps/Release/BuildArchive.php
@@ -61,7 +61,11 @@ class BuildArchive extends ReleaseStep
         $this->log($output, "Generating archives for {$count} recipes");
         foreach ($archives as $archive) {
             // Create project
-            $path = $this->createArchiveFiles($output, $archive);
+            $path = $this->createArchiveFiles(
+                $output,
+                $archive,
+                !$input->getOption('skip-emulate-requirements')
+            );
             foreach ($archive->getFiles() as $file) {
                 // Create file for this project
                 $this->buildFiles($output, $path, $file);
@@ -154,10 +158,11 @@ class BuildArchive extends ReleaseStep
      *
      * @param OutputInterface $output
      * @param Archive $archive
+     * @param bool $emulateRequirements Composer to emulate platform environment aligned with requirements
      * @return string Path to temporary project
      * @throws Exception
      */
-    protected function createArchiveFiles(OutputInterface $output, Archive $archive)
+    protected function createArchiveFiles(OutputInterface $output, Archive $archive, $emulateRequirements)
     {
         $runner = $this->getCommandRunner($output);
         $name = $archive->getRelease()->getLibrary()->getName();
@@ -176,7 +181,7 @@ class BuildArchive extends ReleaseStep
         $this->log($output, "Installing version {$version}");
 
         Composer::createProject($runner, $name, $path, $version, $repository);
-        Composer::update($runner, $path, $repository);
+        Composer::update($runner, $path, $repository, false, false, $emulateRequirements);
 
         // Copy composer.phar to the project
         // Write version info to the core folders (shouldn't be in version control)

--- a/src/Steps/Release/BuildArchive.php
+++ b/src/Steps/Release/BuildArchive.php
@@ -159,9 +159,11 @@ class BuildArchive extends ReleaseStep
      */
     protected function createArchiveFiles(OutputInterface $output, Archive $archive)
     {
+        $runner = $this->getCommandRunner($output);
         $name = $archive->getRelease()->getLibrary()->getName();
         $version = $archive->getRelease()->getVersion()->getValue();
         $path = $archive->getTempDir();
+        $repository = $this->getRepository();
         $this->log($output, "Generating archives for <info>{$name}</info> at <comment>{$path}</comment>");
 
         // Ensure path is empty, but exists
@@ -172,7 +174,9 @@ class BuildArchive extends ReleaseStep
 
         // Install to this location
         $this->log($output, "Installing version {$version}");
-        Composer::createProject($this->getCommandRunner($output), $name, $path, $version, $this->getRepository(), true);
+
+        Composer::createProject($runner, $name, $path, $version, $repository);
+        Composer::update($runner, $path, $repository);
 
         // Copy composer.phar to the project
         // Write version info to the core folders (shouldn't be in version control)

--- a/src/Steps/Release/CreateProject.php
+++ b/src/Steps/Release/CreateProject.php
@@ -75,7 +75,7 @@ class CreateProject extends Step
 
         // Pick and install this version
         $version = $this->getBestVersion($output);
-        $this->installVersion($output, $version);
+        $this->installVersion($output, $version, !$input->getOption('skip-emulate-requirements'));
 
         // Validate result
         if (!Project::isProjectPath($this->directory)) {
@@ -117,8 +117,9 @@ class CreateProject extends Step
      *
      * @param OutputInterface $output
      * @param string $installVersion Composer version to install
+     * @param bool $emulateRequirements Composer to emulate platform environment aligned with requirements
      */
-    protected function installVersion(OutputInterface $output, $installVersion)
+    protected function installVersion(OutputInterface $output, $installVersion, $emulateRequirements)
     {
         $this->log($output, "Installing version <info>{$installVersion}</info> in <info>{$this->directory}</info>");
 
@@ -128,7 +129,7 @@ class CreateProject extends Step
         $repository = $this->getRepository();
 
         Composer::createProject($runner, $recipe, $directory, $installVersion, $repository);
-        Composer::update($runner, $directory, $repository);
+        Composer::update($runner, $directory, $repository, false, false, $emulateRequirements);
     }
 
     /**

--- a/src/Steps/Release/CreateProject.php
+++ b/src/Steps/Release/CreateProject.php
@@ -121,15 +121,14 @@ class CreateProject extends Step
     protected function installVersion(OutputInterface $output, $installVersion)
     {
         $this->log($output, "Installing version <info>{$installVersion}</info> in <info>{$this->directory}</info>");
-        Composer::createProject(
-            $this->getCommandRunner($output),
-            $this->getRecipe(),
-            $this->getDirectory(),
-            $installVersion,
-            $this->getRepository(),
-            false, // prefer-source for base project
-            true // Skip platform-reqs for base release
-        );
+
+        $runner = $this->getCommandRunner($output);
+        $recipe = $this->getRecipe();
+        $directory = $this->getDirectory();
+        $repository = $this->getRepository();
+
+        Composer::createProject($runner, $recipe, $directory, $installVersion, $repository);
+        Composer::update($runner, $directory, $repository);
     }
 
     /**

--- a/src/Utility/Composer.php
+++ b/src/Utility/Composer.php
@@ -72,10 +72,12 @@ class Composer
         $directory,
         $repository = null,
         $preferDist = false,
-        $ignorePlatform = false
+        $ignorePlatform = false,
+        $emulateRequirements = true
     ) {
         // Set composer config
-        $customConfig = self::getUpdateConfig($directory, $repository);
+        $customConfig = self::getUpdateConfig($directory, $repository, $emulateRequirements);
+
         foreach ($customConfig as $option => $arguments) {
             $runner->runCommand(array_merge(
                 ['composer', 'config', $option],
@@ -128,19 +130,21 @@ class Composer
      *
      * @param string $directory
      * @param string $repository
+     * @param bool $emulateRequirements
      * @return array
      */
-    protected static function getUpdateConfig($directory, $repository)
+    protected static function getUpdateConfig($directory, $repository, $emulateRequirements)
     {
         // Register all custom options to temporarily set
         $customConfig = [];
 
-        $composerData = Config::loadFromFile($directory . '/composer.json');
-
-        $customConfig = array_merge(
-            $customConfig,
-            static::requirementsConfig($composerData)
-        );
+        if ($emulateRequirements) {
+            $composerData = Config::loadFromFile($directory . '/composer.json');
+            $customConfig = array_merge(
+                $customConfig,
+                static::requirementsConfig($composerData)
+            );
+        }
 
         // Update un-installed project with custom repository
         if ($repository) {
@@ -206,7 +210,7 @@ class Composer
     /**
      * Read the allowed versions defined in the composer format and return them ordered
      *
-     * @param String $versionDefinition version definition
+     * @param string $versionDefinition version definition
      * @return array ordered list of versions as strings
      *
      * @link https://getcomposer.org/doc/articles/versions.md Composer version format documentation

--- a/src/Utility/Composer.php
+++ b/src/Utility/Composer.php
@@ -29,7 +29,8 @@ class Composer
     }
 
     /**
-     * Install a given version
+     * Create a given version skeleton (aka composer create-project)
+     *
      * @param CommandRunner $runner
      * @param string $recipe
      * @param string $directory
@@ -45,9 +46,8 @@ class Composer
         $version,
         $repository = null,
         $preferDist = false,
-        $ignorePlatform = false
+        $ignorePlatform = true
     ) {
-        // Create comand
         $createOptions = self::getCreateOptions($repository, $preferDist, $ignorePlatform);
         $runner->runCommand(array_merge([
             "composer",
@@ -56,7 +56,24 @@ class Composer
             $directory,
             $version,
         ], $createOptions), "Could not create project with version {$version}");
+    }
 
+    /**
+     * @param CommandRunner $runner
+     * @param string $recipe
+     * @param string $directory
+     * @param string $version
+     * @param string $repository Optional custom repository
+     * @param bool $preferDist Set to true to use dist
+     * @param bool $ignorePlatform Set to true to ignore platform deps
+     */
+    public static function update(
+        CommandRunner $runner,
+        $directory,
+        $repository = null,
+        $preferDist = false,
+        $ignorePlatform = false
+    ) {
         // Set composer config
         $customConfig = self::getUpdateConfig($directory, $repository);
         foreach ($customConfig as $option => $arguments) {
@@ -67,25 +84,27 @@ class Composer
             ));
         }
 
-        // Update with the given repository
-        $updateOptions = self::getUpdateOptions($preferDist, $ignorePlatform);
-        $runner->runCommand(array_merge([
-            'composer',
-            'update',
-            '--working-dir',
-            $directory,
-        ], $updateOptions), "Could not update project");
-
-        // Revert all custom config
-        foreach ($customConfig as $option => $arguments) {
-            $runner->runCommand([
+        try {
+            // Update with the given repository
+            $updateOptions = self::getUpdateOptions($preferDist, $ignorePlatform);
+            $runner->runCommand(array_merge([
                 'composer',
-                'config',
-                '--unset',
-                $option,
+                'update',
                 '--working-dir',
                 $directory,
-            ]);
+            ], $updateOptions), "Could not update project");
+        } finally {
+            // Revert all custom config
+            foreach ($customConfig as $option => $arguments) {
+                $runner->runCommand([
+                    'composer',
+                    'config',
+                    '--unset',
+                    $option,
+                    '--working-dir',
+                    $directory,
+                ]);
+            }
         }
     }
 
@@ -116,13 +135,12 @@ class Composer
         // Register all custom options to temporarily set
         $customConfig = [];
 
-        // If `requirements.php` is specified, set platform to lowest platform version
         $composerData = Config::loadFromFile($directory . '/composer.json');
-        if (isset($composerData['require']['php'])
-            && preg_match('/^[\\D]*(?<version>[\\d.]+)/', $composerData['require']['php'], $matches)
-        ) {
-            $customConfig['platform.php'] = [$matches['version']];
-        }
+
+        $customConfig = array_merge(
+            $customConfig,
+            static::requirementsConfig($composerData)
+        );
 
         // Update un-installed project with custom repository
         if ($repository) {
@@ -131,6 +149,109 @@ class Composer
         }
 
         return $customConfig;
+    }
+
+    /**
+     * Build platform configuration from composer requirements
+     * Does not return the requirements for which the original
+     * composer.json has already got "config.platform.*" defined
+     *
+     * @param array $composerData current composer.json config
+     *
+     * @return array associative array of composer platform config values
+     */
+    private static function requirementsConfig(array $composerData)
+    {
+        $config = [];
+
+        if (!isset($composerData['require'])) {
+            return $config;
+        }
+
+        $requirements = $composerData['require'];
+
+        foreach ($requirements as $package => $version) {
+            if ($package === 'php') {
+                if (isset($composerData['config']['platform']['php'])) {
+                    continue;
+                }
+
+                $versions = static::parseVersions($version);
+
+                if (count($versions)) {
+                    $config['platform.php'] = [$versions[0]];
+                }
+            } elseif (strpos($package, '/') === false && substr($package, 0, 4) === 'ext-') {
+                if (isset($composerData['config']['platform'][$package])) {
+                    continue;
+                }
+
+                $packageKey = sprintf('platform.%s', $package);
+
+                if ($version === '*') {
+                    $config[$packageKey] = ['1'];
+                } else {
+                    $versions = static::parseVersions($version);
+
+                    if (count($versions)) {
+                        $config[$packageKey] = [$versions[0]];
+                    }
+                }
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Read the allowed versions defined in the composer format and return them ordered
+     *
+     * @param String $versionDefinition version definition
+     * @return array ordered list of versions as strings
+     *
+     * @link https://getcomposer.org/doc/articles/versions.md Composer version format documentation
+     *
+     */
+    private static function parseVersions($versionDefinition)
+    {
+        static $regex = '/
+            (?<!(?:<|>|\.|\d))  # Does not start with "<", ">", "." or a number
+                                # that means it may be ">=7.1", "<=7.1", "7.1" but cannot be ">7.1" nor "<7.1"
+                                # We also eliminate partial matches ignoring stuff starting with
+                                # a number or a dot ".", so that ">7.1.25" does not become "1.25" nor "5"
+
+            (?<version>\d+(?:\.\d+(?:\.\d+)?)?)
+        /x';
+
+        if (preg_match_all($regex, $versionDefinition, $matches)
+            && isset($matches['version'])
+            && count($matches['version'])
+        ) {
+            $versions = $matches['version'];
+
+            usort($versions, static function ($a, $b) {
+                $af = floatval($a);
+                $bf = floatval($b);
+
+                if ($af < $bf) {
+                    return -1;
+                } elseif ($af > $bf) {
+                    return 1;
+                } else {
+                    if ($a < $b) {
+                        return -1;
+                    } elseif ($a > $b) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                }
+            });
+
+            return $versions;
+        } else {
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
Implement composer config.platform to emulate lowest requirements of PHP and extensions.

Thus, if composer defines requirement for php>=5.6, composer.lock will be built for PHP 5.6 even if you run cow on the system with php 7.2

Fixes #80