### PR TITLE
FIX Rounding error in PHP 7.2 for rate limit timestamp difference in minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=PSR2 bin/ src/ tests/; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=PSR12 bin/ src/ tests/; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     env: PHPUNIT_COVERAGE_TEST=1
   - php: 7.2
     env: PHPUNIT_TEST=1
+  - php: 7.3
+    env: PHPUNIT_TEST=1
 
 before_script:
   # php setup

--- a/src/Commands/GitHub/RateLimit.php
+++ b/src/Commands/GitHub/RateLimit.php
@@ -56,7 +56,7 @@ class RateLimit extends Command
 
         $now = new DateTime();
         $resetDate = new DateTime();
-        $resetDate->setTimestamp($data['reset']);
+        $resetDate->setTimestamp($data['reset'] + 1);
         $this->output->writeln('Resets in: <comment>' . $resetDate->diff($now)->i . ' mins</comment>');
     }
 }

--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -56,7 +56,7 @@ class Changelog
         $toVersion = $changelogLibrary->getRelease()->getIsNewRelease()
             ? 'HEAD' // Since it won't have been tagged yet, we use the current branch head
             : $changelogLibrary->getRelease()->getVersion()->getValue();
-        $range = $fromVersion."..".$toVersion;
+        $range = $fromVersion . ".." . $toVersion;
         try {
             $log = $changelogLibrary
                 ->getRelease()

--- a/src/Model/Modules/Project.php
+++ b/src/Model/Modules/Project.php
@@ -99,19 +99,19 @@ class Project extends Module
     protected function getDirectories()
     {
         // Search all directories
-        foreach (glob($this->directory."/*", GLOB_ONLYDIR) as $baseDir) {
+        foreach (glob($this->directory . "/*", GLOB_ONLYDIR) as $baseDir) {
             yield $baseDir;
         }
 
         // Add vendor modules
-        foreach (glob($this->directory."/vendor/*", GLOB_ONLYDIR) as $vendorDir) {
-            foreach (glob($vendorDir."/*", GLOB_ONLYDIR) as $moduleDir) {
+        foreach (glob($this->directory . "/vendor/*", GLOB_ONLYDIR) as $vendorDir) {
+            foreach (glob($vendorDir . "/*", GLOB_ONLYDIR) as $moduleDir) {
                 yield $moduleDir;
             }
         }
 
         // Add themes
-        foreach (glob($this->directory."/themes/*", GLOB_ONLYDIR) as $themeDir) {
+        foreach (glob($this->directory . "/themes/*", GLOB_ONLYDIR) as $themeDir) {
             yield $themeDir;
         }
     }

--- a/src/Model/Modules/Theme.php
+++ b/src/Model/Modules/Theme.php
@@ -13,7 +13,7 @@ class Theme extends Module
         if (!static::isLibraryPath($dir)) {
             return false;
         }
-        $data = json_decode(file_get_contents($path.'/composer.json'), true);
+        $data = json_decode(file_get_contents($path . '/composer.json'), true);
         return isset($data['type']) && $data['type'] === 'silverstripe-theme';
     }
 }

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -141,7 +141,7 @@ class CreateChangelog extends ReleaseStep
             if (!is_dir($dirname)) {
                 mkdir($dirname, 0777, true);
             }
-            file_put_contents($fullPath, $header.$content);
+            file_put_contents($fullPath, $header . $content);
             $this->commitChanges($output, $changelogHolder, $version, $fullPath);
         }
 

--- a/src/Steps/Release/CreateProject.php
+++ b/src/Steps/Release/CreateProject.php
@@ -154,7 +154,7 @@ class CreateProject extends Step
             }
         }
 
-        throw new InvalidArgumentException("Could not install project from version ".$this->version->getValue());
+        throw new InvalidArgumentException("Could not install project from version " . $this->version->getValue());
     }
 
     public function getStepName()

--- a/src/Steps/Release/RewriteReleaseBranches.php
+++ b/src/Steps/Release/RewriteReleaseBranches.php
@@ -153,7 +153,7 @@ class RewriteReleaseBranches extends ReleaseStep
             return;
         }
 
-        $this->log($output, "Removing branch alias from <info>".$library->getName()."</info>");
+        $this->log($output, "Removing branch alias from <info>" . $library->getName() . "</info>");
         unset($composerData['extra']['branch-alias']);
 
         // Write changes
@@ -200,8 +200,8 @@ class RewriteReleaseBranches extends ReleaseStep
                 $this->log(
                     $output,
                     "Warning: Dependency <info>{$childName}</info> of parent <info>{$parentName}</info> "
-                    . "was installed with constraint <info>".$childConstraint->getValue()."</info> but is "
-                    . "being released at a lower version <info>".$childVersion->getValue()."</info>",
+                    . "was installed with constraint <info>" . $childConstraint->getValue() . "</info> but is "
+                    . "being released at a lower version <info>" . $childVersion->getValue() . "</info>",
                     "error"
                 );
             }

--- a/src/Steps/Release/UpdateTranslations.php
+++ b/src/Steps/Release/UpdateTranslations.php
@@ -239,7 +239,7 @@ class UpdateTranslations extends ReleaseStep
             );
 
             $num = 0;
-            foreach (glob($module->getLangDirectory()."/*.yml") as $sourceFile) {
+            foreach (glob($module->getLangDirectory() . "/*.yml") as $sourceFile) {
                 $dirty = file_get_contents($sourceFile);
                 $sourceData = Yaml::parse($dirty);
                 $cleaned = Yaml::dump($sourceData, 9999, 2);

--- a/src/Utility/Format.php
+++ b/src/Utility/Format.php
@@ -17,7 +17,7 @@ class Format
     {
         $result = $format;
         foreach ($arguments as $name => $value) {
-            $result = str_replace('{'.$name.'}', $value, $result);
+            $result = str_replace('{' . $name . '}', $value, $result);
         }
         return $result;
     }

--- a/tests/Utility/Filter/SupportedModuleFilterTest.php
+++ b/tests/Utility/Filter/SupportedModuleFilterTest.php
@@ -17,7 +17,7 @@ class SupportedModuleFilterTest extends PHPUnit_Framework_TestCase
             ['name' => 'food', 'type' => 'unsupported-module'],
         ];
 
-        $result = (new SupportedModuleFilter)->filter($input);
+        $result = (new SupportedModuleFilter())->filter($input);
         $this->assertContains(['name' => 'foo', 'type' => 'supported-module'], $result);
         $this->assertContains(['name' => 'bar', 'type' => 'supported-module'], $result);
         $this->assertNotContains(['name' => 'baz', 'type' => 'supported-dependency'], $result);


### PR DESCRIPTION
For some reason in PHP 7.2 Travis builds the timestamp diff is being converted to 4 minutes instead of 5 minutes in RateLimitTest. This massages the timestamp by a second to help it round to 5 minutes.