### PR TITLE
MAJOR When planning you can now indicate that releases should not be created by default

### DIFF
--- a/src/Commands/Release/Plan.php
+++ b/src/Commands/Release/Plan.php
@@ -4,6 +4,8 @@
 namespace SilverStripe\Cow\Commands\Release;
 
 use SilverStripe\Cow\Steps\Release\PlanRelease;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Builds a release plan
@@ -13,6 +15,25 @@ class Plan extends Release
     protected $name = 'release:plan';
 
     protected $description = 'Plan release dependencies';
+
+    protected function configureOptions()
+    {
+        parent::configureOptions();
+
+        $this->addOption(
+            'assume-no-releases',
+            null,
+            InputOption::VALUE_NONE,
+            'Indicate that the plan should not assume that a release will be made for each library (except recipes)'
+        );
+
+        $this->addOption(
+            'release',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Comma delimited list of modules to release when used in combination with --no-releases'
+        );
+    }
 
     protected function fire()
     {


### PR DESCRIPTION
Additionally there is now an option on the command to opt-in to automatically releasing.

- `--assume-no-releases` is the new flag for not auto-releasing
- `--release=comma,delimited,composer,packages` is the new option for opting in to auto-releasing modules