### PR TITLE
FIX Changelog generation now handles SSH remotes when finding repository URL

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -708,7 +708,10 @@ class Library
         // Fallback to checking remotes. E.g. gitlab remotes
         $remotes = $this->getRemotes();
         foreach ($remotes as $name => $remote) {
-            if (preg_match('/^http(s)?:/', $remote)) {
+            // Handle https or ssh endpoints
+            if (preg_match('/^(http(s)?:|git@)/', $remote)) {
+                // Replace ssh protocol with https
+                $remote = preg_replace('/git@(.+):/', 'https://$1/', $remote);
                 // Remove trailing .git
                 $remote = preg_replace('/\\.git$/', '', $remote);
                 $remote = rtrim($remote, '/') . '/commit/{sha}';

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -126,7 +126,7 @@ class Library
         // Guess from git remote
         $remotes = $this->getRemotes();
         foreach ($remotes as $remote) {
-            if (preg_match('#github.com/(?<slug>[^\\s/\\.]+/[^\\s/\\.]+)#', $remote, $matches)) {
+            if (preg_match('#github.com(/|:)(?<slug>[^\\s/\\.]+/[^\\s/\\.]+)#', $remote, $matches)) {
                 return $matches['slug'];
             }
         }

--- a/tests/Model/Modules/LibraryTest.php
+++ b/tests/Model/Modules/LibraryTest.php
@@ -61,4 +61,137 @@ class LibraryTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($library->getChangelogIncludeOtherChanges(), 'Should be false from config');
         $this->assertTrue($library->getChangelogIncludeOtherChanges(), 'Should be true from config');
     }
+
+    public function testGetCommitLinkReturnsFromCowConfig()
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCowData'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getCowData')->willReturn([
+            'commit-link' => 'https://www.silverstripe.org/moo',
+        ]);
+
+        $result = $mock->getCommitLink('foo');
+        $this->assertSame('https://www.silverstripe.org/moo', $result);
+    }
+
+    public function testGetCommitLinkFromGitHubSlug()
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCowData', 'getGithubSlug'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getCowData')->willReturn([]);
+        $mock->expects($this->once())->method('getGithubSlug')->willReturn('silverstripe/cow');
+
+        $result = $mock->getCommitLink('q1w2e3r4t5y6');
+        $this->assertSame('https://github.com/silverstripe/cow/commit/q1w2e3r4t5y6', $result);
+    }
+
+    /**
+     * @param string[] $remotes
+     * @param string $expected
+     * @dataProvider remoteCommitLinkProvider
+     */
+    public function testGetCommitLinkFromRemotes($remotes, $expected)
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCowData', 'getGithubSlug', 'getRemotes'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getCowData')->willReturn([]);
+        $mock->expects($this->once())->method('getGithubSlug')->willReturn(null);
+        $mock->expects($this->once())->method('getRemotes')->willReturn($remotes);
+
+        $result = $mock->getCommitLink('q1w2e3r4t5y6');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function remoteCommitLinkProvider()
+    {
+        return [
+            'https without .git extension and with invalid remote url first' => [
+                [
+                    'www.example.com/gets-skipped',
+                    'https://github.com/silverstripe/cow',
+                ],
+                'https://github.com/silverstripe/cow/commit/q1w2e3r4t5y6',
+            ],
+            'https with .git extension' => [
+                ['https://github.com/silverstripe/cow.git'],
+                'https://github.com/silverstripe/cow/commit/q1w2e3r4t5y6',
+            ],
+            'ssh protocol' => [
+                ['git@github.com:silverstripe/cow.git'],
+                'https://github.com/silverstripe/cow/commit/q1w2e3r4t5y6',
+            ],
+            'no format detected' => [[], null],
+        ];
+    }
+
+    public function testGetGithubSlugFromCowData()
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCowData'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getCowData')->willReturn([
+            'github-slug' => 'silverstripe/moo',
+        ]);
+
+        $this->assertSame('silverstripe/moo', $mock->getGithubSlug());
+    }
+
+    /**
+     * @param string[] $remotes
+     * @param string $expected
+     * @dataProvider remoteSlugProvider
+     */
+    public function testGetGithubSlugFromRemotes($remotes, $expected)
+    {
+        /** @var Library|PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(Library::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCowData', 'getRemotes'])
+            ->getMock();
+
+        $mock->expects($this->once())->method('getCowData')->willReturn([]);
+        $mock->expects($this->once())->method('getRemotes')->willReturn($remotes);
+
+        $this->assertSame($expected, $mock->getGithubSlug());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function remoteSlugProvider()
+    {
+        return [
+            'http(s) github' => [
+                ['https://github.com/silverstripe/cow.git'],
+                'silverstripe/cow',
+            ],
+            'ssh github' => [
+                ['git@github.com:silverstripe/cow.git'],
+                'silverstripe/cow',
+            ],
+            'gitlab' => [
+                ['https:/gitlab.cwp.govt.nz/foo/bar'],
+                null,
+            ],
+            'no matching remote' => [[], null],
+        ];
+    }
 }


### PR DESCRIPTION
Commits from repositories with ssh remotes (e.g. when using VCS forks) don't resolve the repo URLs in the changelogs. This fixes that.