### PR TITLE
NEW Cow now supports CVE identifiers in security commits when categorising commits in changelogs

### DIFF
--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -61,7 +61,7 @@ class ChangelogItem
             // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
             '/^(\[SS-2(\d){3}-(\d){3}\]):?/i',
             // E.g. "[cve-2019-12345]: Security fix"
-            '/^(\[CVE-(\d){4}-(\d){4,5}\]):?/i',
+            '/^(\[CVE-(\d){4}-(\d){4,}\]):?/i',
         ),
         'API Changes' => array(
             '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b:?/'
@@ -286,7 +286,7 @@ class ChangelogItem
         }
 
         // New CVE style identifiers
-        if (preg_match('/^\[(?<cve>CVE-(\d){4}-(\d){4,5})\]/i', $this->getRawMessage(), $matches)) {
+        if (preg_match('/^\[(?<cve>CVE-(\d){4}-(\d){4,})\]/i', $this->getRawMessage(), $matches)) {
             return strtolower($matches['cve']);
         }
     }

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -59,7 +59,9 @@ class ChangelogItem
     protected static $types = array(
         'Security' => array(
             // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
-            '/^(\[SS-2(\d){3}-(\d){3}\]):?/i'
+            '/^(\[SS-2(\d){3}-(\d){3}\]):?/i',
+            // E.g. "[cve-2019-12345]: Security fix"
+            '/^(\[CVE-(\d){4}-(\d){4,5}\]):?/i',
         ),
         'API Changes' => array(
             '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b:?/'
@@ -272,13 +274,19 @@ class ChangelogItem
     }
 
     /**
-     * If this is a security fix, get the CVE/identifier (in 'ss-2015-016' format)
+     * If this is a security fix, get the CVE/identifier (in 'ss-2015-016' or 'CVE-2019-12345' format)
      *
      * @return string|null CVE/identifier, or null if not
      */
     public function getSecurityCVE()
     {
-        if (preg_match('/^\[(?<cve>SS-2(\d){3}-(\d){3})\]/i', $this->getRawMessage(), $matches)) {
+        // Old SS style security identifiers
+        if (preg_match('/^\[(?<ssid>SS-2(\d){3}-(\d){3})\]/i', $this->getRawMessage(), $matches)) {
+            return strtolower($matches['ssid']);
+        }
+
+        // New CVE style identifiers
+        if (preg_match('/^\[(?<cve>CVE-(\d){4}-(\d){4,5})\]/i', $this->getRawMessage(), $matches)) {
             return strtolower($matches['cve']);
         }
     }

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -76,6 +76,11 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['[SS-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
             ['[ss-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
             ['[SS-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
+            ['[SS-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
+            ['[CVE-1234-56789]: Fix something serious', 'Fix something serious', 'Security'],
+            ['[CVE-1234-12345] Remove admin login backdoor', 'Remove admin login backdoor', 'Security'],
+            ['[cve-1234-12345] added admin login backdoor', 'added admin login backdoor', 'Security'],
+            ['[cve-2018-8001] testing is cool', 'testing is cool', 'Security'],
             ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
         ];
     }
@@ -115,6 +120,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['API Changing something big', false],
             ['NEW Enhancing something', false],
             ['[SS-2047-123] Something serious', false],
+            ['[CVE-2019-12345] Fixed something', false],
         ];
     }
 }

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -79,7 +79,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['[ss-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
             ['[CVE-1234-56789]: Fix something serious', 'Fix something serious', 'Security'],
             ['[CVE-1234-12345] Remove admin login backdoor', 'Remove admin login backdoor', 'Security'],
-            ['[cve-1234-12345] added admin login backdoor', 'added admin login backdoor', 'Security'],
+            ['[cve-1234-123456] added admin login backdoor', 'added admin login backdoor', 'Security'],
             ['[cve-2018-8001] testing is cool', 'testing is cool', 'Security'],
             ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
         ];

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -76,7 +76,7 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['[SS-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
             ['[ss-2047-123] Lower doubt with cow coverage', 'Lower doubt with cow coverage', 'Security'],
             ['[SS-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
-            ['[SS-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
+            ['[ss-2047-123]: Logins now use passwords', 'Logins now use passwords', 'Security'],
             ['[CVE-1234-56789]: Fix something serious', 'Fix something serious', 'Security'],
             ['[CVE-1234-12345] Remove admin login backdoor', 'Remove admin login backdoor', 'Security'],
             ['[cve-1234-12345] added admin login backdoor', 'added admin login backdoor', 'Security'],


### PR DESCRIPTION
Resolves https://github.com/silverstripe/cow/issues/131