### PR TITLE
WIP API Introduce changelogs to the planner

### DIFF
--- a/src/Commands/Release/Branch.php
+++ b/src/Commands/Release/Branch.php
@@ -75,7 +75,7 @@ class Branch extends Release
         $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar, $this->versionResolver);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -25,7 +25,7 @@ class Changelog extends Release
         $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar, $this->versionResolver);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Commands/Release/Plan.php
+++ b/src/Commands/Release/Plan.php
@@ -22,7 +22,7 @@ class Plan extends Release
         $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar, $this->versionResolver);
         $buildPlan->run($this->input, $this->output);
     }
 }

--- a/src/Commands/Release/Translate.php
+++ b/src/Commands/Release/Translate.php
@@ -24,7 +24,7 @@ class Translate extends Release
         $branching = $this->getBranching();
 
         // Build and confirm release plan
-        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar);
+        $buildPlan = new PlanRelease($this, $project, $version, $branching, $this->progressBar, $this->versionResolver);
         $buildPlan->run($this->input, $this->output);
         $releasePlan = $buildPlan->getReleasePlan();
 

--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -65,7 +65,7 @@ class Changelog
                 ->getLog($range);
 
             foreach ($log->getCommits() as $commit) {
-                $change = new ChangelogItem($changelogLibrary, $commit, $this->getIncludeOtherChanges());
+                $change = new ChangelogItem($changelogLibrary, $commit);
 
                 // Detect duplicates and skip ignored items
                 $key = $change->getDistinctDetails();
@@ -105,7 +105,7 @@ class Changelog
      * @param OutputInterface $output
      * @return ChangelogItem[]
      */
-    protected function getChanges(OutputInterface $output)
+    public function getChanges(OutputInterface $output)
     {
         $changes = array();
         $libraries = $this->getRootLibrary()->getAllItems(true);
@@ -226,7 +226,7 @@ class Changelog
         $output = '';
         foreach ($commits as $commit) {
             // Skip untyped commits
-            if (!$commit->getType()) {
+            if ($this->getIncludeOtherChanges() || $commit->getType() !== ChangelogItem::TYPE_OTHER_CHANGES) {
                 continue;
             }
             /** @var ChangelogItem $commit */

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -12,6 +12,15 @@ use SilverStripe\Cow\Utility\Format;
 class ChangelogItem
 {
     /**
+     * Type definitions for commit messages
+     */
+    const TYPE_SECURITY = 'Security';
+    const TYPE_API = 'API Changes';
+    const TYPE_ENHANCEMENT = 'Features and Enhancements';
+    const TYPE_BUGFIX = 'Bugfixes';
+    const TYPE_OTHER_CHANGES = 'Other changes';
+
+    /**
      * Changelog library reference this item belongs to
      *
      * @var ChangelogLibrary
@@ -57,19 +66,19 @@ class ChangelogItem
      * @var array
      */
     protected static $types = array(
-        'Security' => array(
+        self::TYPE_SECURITY => array(
             // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
             '/^(\[SS-2(\d){3}-(\d){3}\]):?/i',
             // E.g. "[cve-2019-12345]: Security fix"
             '/^(\[CVE-(\d){4}-(\d){4,}\]):?/i',
         ),
-        'API Changes' => array(
+        self::TYPE_API => array(
             '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b:?/'
         ),
-        'Features and Enhancements' => array(
+        self::TYPE_ENHANCEMENT => array(
             '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b:?/'
         ),
-        'Bugfixes' => array(
+        self::TYPE_BUGFIX => array(
             '/^(BUG FIX|BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\b:?/',
         )
     );
@@ -90,11 +99,10 @@ class ChangelogItem
      * @param ChangelogLibrary $changelogLibrary
      * @param Commit $commit
      */
-    public function __construct(ChangelogLibrary $changelogLibrary, Commit $commit, $includeAllCommits = false)
+    public function __construct(ChangelogLibrary $changelogLibrary, Commit $commit)
     {
         $this->setChangelogLibrary($changelogLibrary);
         $this->setCommit($commit);
-        $this->setIncludeOtherChanges($includeAllCommits);
     }
 
     /**
@@ -222,9 +230,9 @@ class ChangelogItem
     }
 
     /**
-     * Get category for this type
+     * Get category for this type matching one of the type constants in this file
      *
-     * @return string|null Return the category of this commit, or null if uncategorised
+     * @return string
      */
     public function getType()
     {
@@ -240,15 +248,11 @@ class ChangelogItem
 
         // Check for security identifier (not at start of string)
         if ($this->getSecurityCVE()) {
-            return 'Security';
+            return self::TYPE_SECURITY;
         }
 
         // Fallback check to see if we should include all commits
-        if ($this->getIncludeOtherChanges()) {
-            return 'Other changes';
-        }
-
-        return null;
+        return self::TYPE_OTHER_CHANGES;
     }
 
     /**
@@ -343,24 +347,6 @@ class ChangelogItem
     public function setChangelogLibrary($changelogLibrary)
     {
         $this->changelogLibrary = $changelogLibrary;
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getIncludeOtherChanges()
-    {
-        return $this->includeOtherChanges;
-    }
-
-    /**
-     * @param bool $includeOtherChanges
-     * @return $this
-     */
-    public function setIncludeOtherChanges($includeOtherChanges)
-    {
-        $this->includeOtherChanges = (bool) $includeOtherChanges;
         return $this;
     }
 }

--- a/src/Model/Release/LibraryRelease.php
+++ b/src/Model/Release/LibraryRelease.php
@@ -3,6 +3,7 @@
 
 namespace SilverStripe\Cow\Model\Release;
 
+use Exception;
 use Generator;
 use SilverStripe\Cow\Commands\Release\Branch;
 use SilverStripe\Cow\Model\Modules\Library;
@@ -138,6 +139,30 @@ class LibraryRelease
         }
 
         return null;
+    }
+
+    /**
+     * @param string $name The name of the library to find the parent of
+     * @return LibraryRelease
+     * @throws Exception
+     */
+    public function getParentOfItem($name)
+    {
+        if ($name === $this->getLibrary()->getName()) {
+            throw new Exception('There is no parent of the current release!');
+        }
+
+        foreach ($this->items as $child) {
+            if ($child->getLibrary()->getName() === $name) {
+                return $this;
+            }
+
+            if (count($child->getItems())) {
+                return $child->getParentOfItem($name);
+            }
+        }
+
+        throw new Exception(sprintf('Could not determine parent of %s. Does the given library exist?', $name));
     }
 
     /**

--- a/src/Model/Release/LibraryRelease.php
+++ b/src/Model/Release/LibraryRelease.php
@@ -272,11 +272,11 @@ class LibraryRelease
             $constraint = $composerData['require'][$childName];
 
             // Attempt to resolve a specific version from the constraint
-            if (!preg_match('/^\d+\.\d+\.\d+/', $constraint, $matches)) {
+            if (!Version::parse($constraint)) {
                 continue;
             }
 
-            $childPriorVersions[$childName] = new Version($matches[0]);
+            $childPriorVersions[$childName] = new Version($constraint);
         }
 
         return $this->childPriorVersions = $childPriorVersions;

--- a/src/Service/VersionResolver.php
+++ b/src/Service/VersionResolver.php
@@ -1,0 +1,191 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\Cow\Service;
+
+use Exception;
+use SilverStripe\Cow\Model\Modules\Library;
+use SilverStripe\Cow\Model\Release\ComposerConstraint;
+use SilverStripe\Cow\Model\Release\LibraryRelease;
+use SilverStripe\Cow\Model\Release\Version;
+
+class VersionResolver
+{
+    /**
+     * The library that this version resolver should be providing a version for
+     *
+     * @var Library
+     */
+    private $library;
+
+    /**
+     * The parent release that has a constraint on the given library that's being released
+     *
+     * @var LibraryRelease
+     */
+    private $parentRelease;
+
+    /**
+     * VersionResolver constructor.
+     * @param Library $library
+     * @param LibraryRelease $parentRelease
+     */
+    public function __construct(Library $library, LibraryRelease $parentRelease)
+    {
+        $this->library = $library;
+        $this->parentRelease = $parentRelease;
+    }
+
+    /**
+     * Resolve a new version for the library given the parent release constraints
+     *
+     * @return LibraryRelease
+     * @throws Exception
+     */
+    public function createRelease()
+    {
+        $priorRelease = $this->parentRelease->getPriorVersionForChild($this->library);
+
+        return new LibraryRelease($this->library, $this->proposeVersion(), $priorRelease);
+    }
+
+    /**
+     * Propose a new version for the library
+     *
+     * @throws Exception
+     */
+    public function proposeVersion()
+    {
+        // Check if the library should inherit the version of the parent release
+        $parent = $this->parentRelease;
+        $childModule = $this->library;
+        $upgradeOnly = $parent->getLibrary()->isChildUpgradeOnly($childModule->getName());
+
+        if ($this->getConstraint()->isSelfVersion()) {
+            $candidateVersion = $parent->getVersion();
+
+            // If we aren't allowed to release ("upgrade-only") and there's no release matching the parent then we're
+            // in an invalid state
+            if ($upgradeOnly && !array_key_exists($candidateVersion->getValue(), $this->library->getTags())) {
+                throw new Exception(
+                    "Library " . $this->library->getName() . " cannot be upgraded to version "
+                    . $candidateVersion->getValue() . " without a new release"
+                );
+            }
+
+            return $candidateVersion;
+        }
+
+        // Get the latest existing version (tag)
+        $existingVersion = $this->getLatestExistingVersion();
+
+        // If we're "upgrade only" then use the latest existing version
+        if ($upgradeOnly) {
+            if (!$existingVersion) {
+                throw new Exception(
+                    "Library " . $this->library->getName() . " has no available tags that matches "
+                    . $this->getConstraint()->getValue()
+                    . ". Please remove upgrade-only for this module, or tag a new release."
+                );
+            }
+            return $existingVersion;
+        }
+
+        // Check if the head commit is already tagged with the existing version (if available)
+        if ($existingVersion && $childModule->getRepository()->getReferences()->hasTag((string) $existingVersion)) {
+            return $existingVersion;
+        }
+
+        return $this->proposeNewReleaseVersion();
+    }
+
+    /**
+     * Get the latest existing version for the module that's relevant given the constraint on the parent release
+     *
+     * @return null|Version
+     */
+    public function getLatestExistingVersion()
+    {
+        // Get all stable tags that match the given composer constraint
+        $tags = $this->library->getTags();
+        $constraint = $this->getConstraint();
+        $candidates = $constraint->filterVersions($tags);
+
+        // If releasing a stable version, remove all unstable dependencies
+        if ($this->parentRelease->getVersion()->isStable()) {
+            foreach ($candidates as $tag => $version) {
+                if (!$version->isStable()) {
+                    unset($candidates[$tag]);
+                }
+            }
+        }
+
+        // Check if we have any candidates left
+        if (empty($candidates)) {
+            return null;
+        }
+
+        // Upgrade to highest version
+        $tags = Version::sort($candidates, 'descending');
+        return reset($tags);
+    }
+
+    /**
+     * Propose a new version to tag for a given dependency
+     *
+     * @return Version
+     * @throws Exception
+     */
+    public function proposeNewReleaseVersion()
+    {
+        $childModule = $this->library;
+        $parentRelease = $this->parentRelease;
+
+        // Get tags and composer constraint to filter by
+        $tags = $childModule->getTags();
+        $constraint = $parentRelease->getLibrary()->getChildConstraint(
+            $childModule->getName(),
+            $parentRelease->getVersion()
+        );
+
+        // Get stability to use for the new tag
+        $useSameStability = $parentRelease->getLibrary()->isStabilityInherited($childModule);
+        if ($useSameStability) {
+            $stability = $parentRelease->getVersion()->getStability();
+            $stabilityVersion = $parentRelease->getVersion()->getStabilityVersion();
+        } else {
+            $stability = '';
+            $stabilityVersion = null;
+        }
+
+        // Filter versions
+        $candidates = $constraint->filterVersions($tags);
+        $tags = Version::sort($candidates, 'descending');
+
+        // Determine which best tag to create (with the correct stability)
+        $existingTag = reset($tags);
+        if ($existingTag) {
+            // Increment from to guess next version
+            return $existingTag->getNextVersion($stability, $stabilityVersion);
+        }
+        // In this case, the lower bounds of the constraint isn't a valid tag,
+        // so this is our new candidate
+        $version = clone $constraint->getMinVersion();
+        $version->setStability($stability);
+        $version->setStabilityVersion($stabilityVersion);
+
+        return $version;
+    }
+
+    /**
+     * Get the constraint for the module that's defined by the parent release
+     *
+     * @return ComposerConstraint
+     */
+    protected function getConstraint()
+    {
+        return $this->parentRelease->getLibrary()->getChildConstraint(
+            $this->library->getName(),
+            $this->parentRelease->getVersion()
+        );
+    }
+}

--- a/src/Service/VersionResolver.php
+++ b/src/Service/VersionResolver.php
@@ -11,107 +11,103 @@ use SilverStripe\Cow\Model\Release\Version;
 class VersionResolver
 {
     /**
-     * The library that this version resolver should be providing a version for
+     * Cached proposed versions preventing multiple scans of a composer dependency tree
      *
-     * @var Library
+     * @var array
      */
-    private $library;
-
-    /**
-     * The parent release that has a constraint on the given library that's being released
-     *
-     * @var LibraryRelease
-     */
-    private $parentRelease;
-
-    /**
-     * VersionResolver constructor.
-     * @param Library $library
-     * @param LibraryRelease $parentRelease
-     */
-    public function __construct(Library $library, LibraryRelease $parentRelease)
-    {
-        $this->library = $library;
-        $this->parentRelease = $parentRelease;
-    }
-
-    /**
-     * Resolve a new version for the library given the parent release constraints
-     *
-     * @return LibraryRelease
-     * @throws Exception
-     */
-    public function createRelease()
-    {
-        $priorRelease = $this->parentRelease->getPriorVersionForChild($this->library);
-
-        return new LibraryRelease($this->library, $this->proposeVersion(), $priorRelease);
-    }
+    private $proposedVersionCache = [];
 
     /**
      * Propose a new version for the library
      *
+     * @param Library $library The library that this resolver should be providing a version for
+     * @param LibraryRelease $parentRelease The parent release that has the constraint on the library
+     * @return Version|null
      * @throws Exception
      */
-    public function proposeVersion()
+    public function proposeVersion(Library $library, LibraryRelease $parentRelease)
     {
-        // Check if the library should inherit the version of the parent release
-        $parent = $this->parentRelease;
-        $childModule = $this->library;
-        $upgradeOnly = $parent->getLibrary()->isChildUpgradeOnly($childModule->getName());
+        // Generate a key for the cache
+        $cacheKey = sprintf(
+            '%s||%s@%s',
+            $library->getName(),
+            $parentRelease->getLibrary()->getName(),
+            $parentRelease->getVersion()->getValue()
+        );
 
-        if ($this->getConstraint()->isSelfVersion()) {
-            $candidateVersion = $parent->getVersion();
+        if (isset($this->proposedVersionCache[$cacheKey])) {
+            $this->proposedVersionCache[$cacheKey];
+        }
+
+        // Check if the library should inherit the version of the parent release
+        $upgradeOnly = $parentRelease->getLibrary()->isChildUpgradeOnly($library->getName());
+        $constraint = $this->getConstraint($library, $parentRelease);
+
+        if ($constraint->isSelfVersion()) {
+            $candidateVersion = $parentRelease->getVersion();
 
             // If we aren't allowed to release ("upgrade-only") and there's no release matching the parent then we're
             // in an invalid state
-            if ($upgradeOnly && !array_key_exists($candidateVersion->getValue(), $this->library->getTags())) {
+            if ($upgradeOnly && !array_key_exists($candidateVersion->getValue(), $library->getTags())) {
                 throw new Exception(
-                    "Library " . $this->library->getName() . " cannot be upgraded to version "
+                    "Library " . $library->getName() . " cannot be upgraded to version "
                     . $candidateVersion->getValue() . " without a new release"
                 );
             }
 
-            return $candidateVersion;
+            return $this->proposedVersionCache[$cacheKey] = $candidateVersion;
         }
 
         // Get the latest existing version (tag)
-        $existingVersion = $this->getLatestExistingVersion();
+        $existingVersion = $this->getLatestExistingVersion($library, $parentRelease);
 
         // If we're "upgrade only" then use the latest existing version
         if ($upgradeOnly) {
             if (!$existingVersion) {
                 throw new Exception(
-                    "Library " . $this->library->getName() . " has no available tags that matches "
-                    . $this->getConstraint()->getValue()
+                    "Library " . $library->getName() . " has no available tags that matches "
+                    . $constraint->getValue()
                     . ". Please remove upgrade-only for this module, or tag a new release."
                 );
             }
-            return $existingVersion;
+            return $this->proposedVersionCache[$cacheKey] = $existingVersion;
         }
 
-        // Check if the head commit is already tagged with the existing version (if available)
-        if ($existingVersion && $childModule->getRepository()->getReferences()->hasTag((string) $existingVersion)) {
-            return $existingVersion;
+        // Check to see if:
+        // - We don't have an existing version that makes sense, or
+        // - There are any commits on the HEAD that aren't part of the existing version, or
+        if (!$existingVersion
+            || (int) $library->getRepository()->run('rev-list', ['--count', $existingVersion.'..HEAD']) > 0
+        ) {
+            return $this->proposedVersionCache[$cacheKey] = $this->proposeNewReleaseVersion($library, $parentRelease);
         }
 
-        return $this->proposeNewReleaseVersion();
+        // Check to see if there are no children of this library. This means we can say "no release" if we've got this
+        // far
+        if (empty($library->getChildrenExclusive())) {
+            return $this->proposedVersionCache[$cacheKey] = $existingVersion;
+        }
+
+        // The version is indeterminate. Some of the children of this library might need to be released, which means
+        // this library should be released too. It will have to be deferred.
+        return null;
     }
 
     /**
      * Get the latest existing version for the module that's relevant given the constraint on the parent release
      *
+     * @param Library $library The library that this version resolver should be providing a version for
+     * @param LibraryRelease $parentRelease The parent release that has the constraint on the library
      * @return null|Version
      */
-    public function getLatestExistingVersion()
+    public function getLatestExistingVersion(Library $library, LibraryRelease $parentRelease)
     {
         // Get all stable tags that match the given composer constraint
-        $tags = $this->library->getTags();
-        $constraint = $this->getConstraint();
-        $candidates = $constraint->filterVersions($tags);
+        $tags = $library->getTags();
+        $candidates = $this->getConstraint($library, $parentRelease)->filterVersions($tags);
 
         // If releasing a stable version, remove all unstable dependencies
-        if ($this->parentRelease->getVersion()->isStable()) {
+        if ($parentRelease->getVersion()->isStable()) {
             foreach ($candidates as $tag => $version) {
                 if (!$version->isStable()) {
                     unset($candidates[$tag]);
@@ -132,23 +128,21 @@ class VersionResolver
     /**
      * Propose a new version to tag for a given dependency
      *
+     * @param Library $library The library that this version resolver should be providing a version for
+     * @param LibraryRelease $parentRelease The parent release that has the constraint on the library
      * @return Version
-     * @throws Exception
      */
-    public function proposeNewReleaseVersion()
+    public function proposeNewReleaseVersion(Library $library, LibraryRelease $parentRelease)
     {
-        $childModule = $this->library;
-        $parentRelease = $this->parentRelease;
-
         // Get tags and composer constraint to filter by
-        $tags = $childModule->getTags();
+        $tags = $library->getTags();
         $constraint = $parentRelease->getLibrary()->getChildConstraint(
-            $childModule->getName(),
+            $library->getName(),
             $parentRelease->getVersion()
         );
 
         // Get stability to use for the new tag
-        $useSameStability = $parentRelease->getLibrary()->isStabilityInherited($childModule);
+        $useSameStability = $parentRelease->getLibrary()->isStabilityInherited($library);
         if ($useSameStability) {
             $stability = $parentRelease->getVersion()->getStability();
             $stabilityVersion = $parentRelease->getVersion()->getStabilityVersion();
@@ -179,13 +173,15 @@ class VersionResolver
     /**
      * Get the constraint for the module that's defined by the parent release
      *
+     * @param Library $library The library to get the constraint for
+     * @param LibraryRelease $parentRelease The parent release that has the constraint on the library
      * @return ComposerConstraint
      */
-    protected function getConstraint()
+    protected function getConstraint(Library $library, LibraryRelease $parentRelease)
     {
-        return $this->parentRelease->getLibrary()->getChildConstraint(
-            $this->library->getName(),
-            $this->parentRelease->getVersion()
+        return $parentRelease->getLibrary()->getChildConstraint(
+            $library->getName(),
+            $parentRelease->getVersion()
         );
     }
 }

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -189,6 +189,9 @@ class PlanRelease extends Step
             $parentRelease->getVersion()
         );
 
+        // Check if the prior release is known
+        $priorRelease = $parentRelease->getPriorVersionForChild($childModule);
+
         // Upgrade to self.version
         if ($constraint->isSelfVersion()) {
             $candidateVersion = $parentRelease->getVersion();
@@ -198,7 +201,7 @@ class PlanRelease extends Step
                     . $candidateVersion->getValue() . " without a new release"
                 );
             }
-            return new LibraryRelease($childModule, $candidateVersion);
+            return new LibraryRelease($childModule, $candidateVersion, $priorRelease);
         }
 
         // Get all stable tags that match the given composer constraint
@@ -225,7 +228,7 @@ class PlanRelease extends Step
         // Upgrade to highest version
         $tags = Version::sort($candidates, 'descending');
         $candidateVersion = reset($tags);
-        return new LibraryRelease($childModule, $candidateVersion);
+        return new LibraryRelease($childModule, $candidateVersion, $priorRelease);
     }
 
     /**
@@ -245,17 +248,21 @@ class PlanRelease extends Step
             $parentRelease->getVersion()
         );
 
+
+        // Check if the prior release is known
+        $priorRelease = $parentRelease->getPriorVersionForChild($childModule);
+
         // Upgrade to self.version
         if ($constraint->isSelfVersion()) {
             $candidateVersion = $parentRelease->getVersion();
 
             // If this is already tagged, just upgrade without a new release
             if (array_key_exists($candidateVersion->getValue(), $tags)) {
-                return new LibraryRelease($childModule, $candidateVersion);
+                return new LibraryRelease($childModule, $candidateVersion, $priorRelease);
             }
 
             // Build release
-            return new LibraryRelease($childModule, $candidateVersion);
+            return new LibraryRelease($childModule, $candidateVersion, $priorRelease);
         }
 
         // Get stability to use for the new tag
@@ -286,7 +293,7 @@ class PlanRelease extends Step
         }
 
         // Report new tag
-        return new LibraryRelease($childModule, $version);
+        return new LibraryRelease($childModule, $version, $priorRelease);
     }
 
     /**


### PR DESCRIPTION
This will compare the "prior release" to the currently checked out commit of the release project. The information is presented in a summary form, as a git log, and a GitHub compare link is provided

![image](https://user-images.githubusercontent.com/3260989/63233351-d3b6fd00-c283-11e9-94bc-ddcced4c7437.png)

This is based off of the #143 PR branch.

WIP because I think this needs:

- [x] Don't show the changelog when asking for a prior version
- [x] Some indication of where intermediary tags exist in the given log
- [ ] I think the log is showing merge commits. Probably doesn't need that
- [x] Preferably some smarts to calculate whether the current branch of the release project already matches the previously released tag.
- [ ] Tests
