### PR TITLE
Add docker configs, docker/cow script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 /temp
 .idea/
+/docker/cache/composer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,83 @@
+FROM php:7.3-cli-stretch as base
+
+ARG UID=1000
+ARG GID=${UID}
+
+RUN apt-get update -y \
+ && apt-get install -y \
+    unzip wget \
+    libfreetype6-dev libjpeg62-turbo-dev libpng-dev libmemcached-dev \
+    zlib1g-dev libicu-dev libpq-dev libtidy-dev libzip-dev \
+    libldap-dev libgmp-dev \
+    libmagickwand-dev  # for the image magick extension (imagick)
+
+RUN docker-php-source extract \
+ && docker-php-ext-install iconv \
+ && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+ && docker-php-ext-install gd \
+ && docker-php-ext-install intl \
+ && docker-php-ext-install zip \
+ && docker-php-ext-install ldap \
+ && docker-php-ext-install gmp \
+ && docker-php-ext-install mysqli \
+ && docker-php-ext-install pgsql \
+ && docker-php-ext-install pdo \
+ && docker-php-ext-install pdo_mysql \
+ && docker-php-ext-install pdo_pgsql \
+ && docker-php-ext-install tidy \
+ && docker-php-ext-install exif \
+ && docker-php-ext-install bcmath \
+ && docker-php-ext-install bz2 \
+ && yes '' | pecl install memcached && docker-php-ext-enable memcached \
+ && yes '' | pecl install redis && docker-php-ext-enable redis \
+ && yes '' | pecl install imagick && docker-php-ext-enable imagick \
+ && yes '' | pecl install apcu && docker-php-ext-enable apcu \
+ && docker-php-source delete
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && php -r "if (hash_file('sha384', 'composer-setup.php') === '$(wget -q -O - https://composer.github.io/installer.sig)') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+ && php composer-setup.php --install-dir=/bin --filename=composer \
+ && php -r "unlink('composer-setup.php');"
+
+RUN echo "Group ID: ${GID}" \
+ && echo "User ID: ${UID}" \
+ && groupadd -f -g ${GID} cow \
+ && useradd -g ${GID} -d /home/cow -m -u ${UID} cow \
+ && mkdir -p /home/cow/.composer/cache \
+ && chown -R cow:cow /home/cow/.composer
+
+
+FROM base as stable
+
+USER root
+RUN apt-get update -y \
+ && apt-get install -y git python3-pip \
+ && pip3 install -U pip \
+ && pip install transifex-client awscli \
+ && apt-get install -y ruby \
+ && gem install yamlclean
+
+USER cow
+RUN composer -vvv global require silverstripe/cow:dev-master \
+ && composer -vvv global require composer/satis ^1
+
+USER root
+RUN ln -s /home/cow/.composer/vendor/bin/cow /usr/bin/. \
+ && ln -s /home/cow/.composer/vendor/bin/satis /usr/bin/.
+
+USER cow
+
+
+FROM stable as dev
+USER cow
+
+
+FROM dev as debug
+
+USER root
+
+RUN docker-php-source extract \
+ && yes '' | pecl install xdebug-2.7.0beta1 && docker-php-ext-enable xdebug \
+ && docker-php-source delete
+
+USER cow

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+
+x-build-args: &build-args
+  UID: ${USER_ID}
+
+x-entrypoint: &entrypoint
+  - /bin/bash
+  - /app/docker/entrypoint.sh
+
+x-volumes: &volumes
+  - '..:/app'
+  - './cache/composer:/home/cow/.composer/cache'
+
+x-build-context: &build-context .
+
+x-wdir: &wdir /app
+
+services:
+  cow_dev:
+    build:
+      context: *build-context
+      target: dev
+      args: *build-args
+    working_dir: *wdir
+    network_mode: 'host'
+    volumes: *volumes
+    entrypoint: *entrypoint

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ ! -d "/app/vendor" ]] ; then
+    cd /app;
+    composer install --prefer-dist -vv;
+    cd -;
+fi
+
+/app/bin/cow $@

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TGT_DIR=$(pwd)  # the target folder where we run cow from
+
+export USER_ID=$(id -u)
+
+CUR_FILE=$(readlink -f "$0")
+CUR_DIR=$(dirname $CUR_FILE)
+
+cd $CUR_DIR && \
+docker-compose run -e UID=$USER_ID -u $USER_ID --rm -v "$TGT_DIR:/mnt" -w /mnt cow_dev $@

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,14 @@ The ineptly named tool which may one day supercede the older [build tools](https
 
 ## Install
 
+### Docker
+
+Assuming you have docker, docker-compose and bash installed, you don't need any extra steps and can use cow straight away through `docker/run` script. You can use it from any other place on your drive - it will automatically mount the current folder as the working directory.
+
+E.g: `../cow/docker/run release:create 4.5.1`
+
+### Native
+
 You can install this globally with the following commands
 
 ```


### PR DESCRIPTION
This PR adds an alternative way to install COW locally. That means you don't have to install (and keep updated) all the dependencies natively on your host machine: `php`, `python`, `ruby`, `transifex-client`, `pip`, `yamlclean`, `satis` etc.
The only requirement for that setup would be docker itself and docker-compose.

This doesn't prevent you from installing everything natively on the host machine, just gives another option.

That's the setup I've been using locally for the last couple of releases, so I decided to share it.

This particular PR doesn't cover the publishing use case (e.g. the container doesn't have API keys, nor ssh-keys in the current config), but I think that could be covered by another PR in the future.