### PR TITLE
Docker config add xdebug capability

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,2 @@
+XDEBUG_HOST=localhost
+XDEBUG_PORT=9000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,4 @@
-FROM php:7.3-cli-stretch as base
-
-ARG UID=1000
-ARG GID=${UID}
+FROM php:7.3-cli-stretch as php
 
 RUN apt-get update -y \
  && apt-get install -y \
@@ -39,13 +36,18 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
  && php composer-setup.php --install-dir=/bin --filename=composer \
  && php -r "unlink('composer-setup.php');"
 
+
+FROM php as base
+
+ARG UID=1000
+ARG GID=${UID}
+
 RUN echo "Group ID: ${GID}" \
  && echo "User ID: ${UID}" \
  && groupadd -f -g ${GID} cow \
  && useradd -g ${GID} -d /home/cow -m -u ${UID} cow \
  && mkdir -p /home/cow/.composer/cache \
  && chown -R cow:cow /home/cow/.composer
-
 
 FROM base as stable
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,46 @@
+# Docker setup for running Cow
+
+The `docker` folder contains everything related to the docker setup, its configs and shims.
+
+The main idea is that users don't have to know anything about docker or its configs.
+The only requirement is to have Docker installed.
+
+To allow that we provide `shims` - bash scripts implementing shortcuts for the most common use cases.
+
+`docker/.env` file contains some configuration parameters (e.g. xdebug configs)
+
+The `Dockerfile` builds environment on top of an official php container from dockerhub,
+installing all the PHP extensions necessary as well as 3rd party dependencies of COW
+(such as git, composer, ruby gems and transifex client).
+
+`docker-compose.yml` contains a set of configurations for different use cases such as running cow for development, debugging, running tests, debugging tests, running code sniffer and running cow in production mode.
+Although you may run any of these configs straightforwardly by runnig docker-compose if you want, the idea is to run them
+through `shims` that facilitate environment control, propagation of environment variables and required settings.
+
+
+# Shims
+
+## ./docker/run
+
+Running `./bin/cow` transparently within a container.
+
+This script runs cow in development mode by mounting current folder (`$(pwd)`) into the container preserving the path.
+It also uses the current cow folder as is, so if you patched any scripts, the changes will be runnnig exactly as is within the container.
+
+## ./docker/test
+
+This script runs all the unit tests within a container
+
+## ./docker/phpcs
+
+This script runs phpcs within the container
+
+## ./docker/dbg
+
+This script does the same as `./docker/run`, however the container will have XDebug installed and activated, so you can
+debug cow. XDebug configuration settings can be controlled through `.env` file.
+
+## ./docker/dbg-test
+
+This script does the same as `./docker/test`, however the container will have XDebug installed and activated, so you can
+debug unit tests. XDebug configuration settings can be controlled through `.env` file.

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,7 @@ through `shims` that facilitate environment control, propagation of environment 
 Running `./bin/cow` transparently within a container.
 
 This script runs cow in development mode by mounting current folder (`$(pwd)`) into the container preserving the path.
-It also uses the current cow folder as is, so if you patched any scripts, the changes will be runnnig exactly as is within the container.
+It also uses the current cow folder as is, so if you patched any scripts, the changes will be running exactly as is within the container.
 
 ## ./docker/test
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ installing all the PHP extensions necessary as well as 3rd party dependencies of
 (such as git, composer, ruby gems and transifex client).
 
 `docker-compose.yml` contains a set of configurations for different use cases such as running cow for development, debugging, running tests, debugging tests, running code sniffer and running cow in production mode.
-Although you may run any of these configs straightforwardly by runnig docker-compose if you want, the idea is to run them
+Although you may run any of these configs straightforwardly by running docker-compose if you want, the idea is to run them
 through `shims` that facilitate environment control, propagation of environment variables and required settings.
 
 

--- a/docker/dbg
+++ b/docker/dbg
@@ -2,7 +2,11 @@
 
 # Run XDebug session for COW
 
+# Portable versions of the path functions (should work on Linux, MacOS and Windows)
+function _dirname() { python -c 'import sys; from os.path import realpath, dirname; print(dirname(realpath(sys.argv[-1])))' $@ ; }
+function _realpath() { python -c 'import sys; from os.path import realpath; print(realpath(sys.argv[-1]))' $@ ; }
+
 SKIP_RUN_EXEC="1"
-. "$(dirname $(readlink -f "$0"))/run"
+. "$(_dirname $(_realpath -f "$0"))/run"
 
 run_docker_compose cow_debug $@

--- a/docker/dbg
+++ b/docker/dbg
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SKIP_RUN_EXEC="1"
+. "$(dirname $(readlink -f "$0"))/run"
+
+run_docker_compose cow_debug $@

--- a/docker/dbg-test
+++ b/docker/dbg-test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run XDebug session for phpunit tests
+
+SKIP_RUN_EXEC="1"
+. "$(dirname $(readlink -f "$0"))/run"
+
+run_docker_compose cow_debug_test $@

--- a/docker/dbg-test
+++ b/docker/dbg-test
@@ -2,7 +2,11 @@
 
 # Run XDebug session for phpunit tests
 
+# Portable versions of the path functions (should work on Linux, MacOS and Windows)
+function _dirname() { python -c 'import sys; from os.path import realpath, dirname; print(dirname(realpath(sys.argv[-1])))' $@ ; }
+function _realpath() { python -c 'import sys; from os.path import realpath; print(realpath(sys.argv[-1]))' $@ ; }
+
 SKIP_RUN_EXEC="1"
-. "$(dirname $(readlink -f "$0"))/run"
+. "$(_dirname $(_realpath -f "$0"))/run"
 
 run_docker_compose cow_debug_test $@

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,3 +25,16 @@ services:
     network_mode: 'host'
     volumes: *volumes
     entrypoint: *entrypoint
+
+  cow_debug:
+    build:
+      context: *build-context
+      target: debug
+      args: *build-args
+    working_dir: *wdir
+    network_mode: 'host'
+    volumes: *volumes
+    entrypoint: *entrypoint
+    environment:
+      DEBUG_COW: 1
+      XDEBUG_CONFIG: 'remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,3 +67,15 @@ services:
       TEST_COW: 1
       DEBUG_COW: 1
       XDEBUG_CONFIG: *x-debug-env-var
+
+  cow_phpcs:
+    build:
+      context: *build-context
+      target: dev
+      args: *build-args
+    working_dir: *wdir
+    network_mode: 'host'
+    volumes: *volumes
+    entrypoint: *entrypoint
+    environment:
+      PHPCS_COW: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,8 +10,10 @@ x-entrypoint: &entrypoint
 x-volumes: &volumes
   - '..:/app'
   - './cache/composer:/home/cow/.composer/cache'
+  - '${GIT_CONFIG}:/home/cow/.gitconfig:ro'
+  - '~/.ssh:/home/cow/.ssh:ro'
 
-x-debug-env-var: &x-debug-env-var 'remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0'
+x-debug-env-var: &x-debug-env-var 'remote_enable=1 remote_mode=req remote_port=${XDEBUG_PORT} remote_host=${XDEBUG_HOST} remote_connect_back=0'
 
 x-build-context: &build-context .
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,8 @@ x-volumes: &volumes
   - '..:/app'
   - './cache/composer:/home/cow/.composer/cache'
 
+x-debug-env-var: &x-debug-env-var 'remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0'
+
 x-build-context: &build-context .
 
 x-wdir: &wdir /app
@@ -37,4 +39,31 @@ services:
     entrypoint: *entrypoint
     environment:
       DEBUG_COW: 1
-      XDEBUG_CONFIG: 'remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0'
+      XDEBUG_CONFIG: *x-debug-env-var
+
+  cow_test:
+    build:
+      context: *build-context
+      target: dev
+      args: *build-args
+    working_dir: *wdir
+    network_mode: 'host'
+    volumes: *volumes
+    entrypoint: *entrypoint
+    environment:
+      TEST_COW: 1
+      DEBUG_COW: 1
+
+  cow_debug_test:
+    build:
+      context: *build-context
+      target: debug
+      args: *build-args
+    working_dir: *wdir
+    network_mode: 'host'
+    volumes: *volumes
+    entrypoint: *entrypoint
+    environment:
+      TEST_COW: 1
+      DEBUG_COW: 1
+      XDEBUG_CONFIG: *x-debug-env-var

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,4 +14,10 @@ if [[ ! -d "$DIR/vendor" ]] ; then
     cd -;
 fi
 
+if [ ! -z "$TEST_COW" ] ; then
+    cd $DIR;
+    ./vendor/bin/phpunit $@;
+    exit;
+fi
+
 $DIR/bin/cow $@

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-if [[ ! -d "/app/vendor" ]] ; then
-    cd /app;
+if [ ! -z "$DEBUG_COW" ] ; then
+    DIR="$COW_DIR";
+else
+    DIR="/app";
+fi
+
+DIR="$(readlink -f $DIR)";
+
+if [[ ! -d "$DIR/vendor" ]] ; then
+    cd $DIR;
     composer install --prefer-dist -vv;
     cd -;
 fi
 
-/app/bin/cow $@
+$DIR/bin/cow $@

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,4 +20,10 @@ if [ ! -z "$TEST_COW" ] ; then
     exit;
 fi
 
+if [ ! -z "$PHPCS_COW" ] ; then
+    cd $DIR;
+    ./vendor/bin/phpcs --standard=PSR12 bin/ src/ tests/ $@;
+    exit;
+fi
+
 $DIR/bin/cow $@

--- a/docker/phpcs
+++ b/docker/phpcs
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run COW tests (phpunit)
+
+SKIP_RUN_EXEC="1"
+. "$(dirname $(readlink -f "$0"))/run"
+
+run_docker_compose cow_phpcs $@

--- a/docker/phpcs
+++ b/docker/phpcs
@@ -2,7 +2,11 @@
 
 # Run COW tests (phpunit)
 
+# Portable versions of the path functions (should work on Linux, MacOS and Windows)
+function _dirname() { python -c 'import sys; from os.path import realpath, dirname; print(dirname(realpath(sys.argv[-1])))' $@ ; }
+function _realpath() { python -c 'import sys; from os.path import realpath; print(realpath(sys.argv[-1]))' $@ ; }
+
 SKIP_RUN_EXEC="1"
-. "$(dirname $(readlink -f "$0"))/run"
+. "$(_dirname $(_realpath -f "$0"))/run"
 
 run_docker_compose cow_phpcs $@

--- a/docker/run
+++ b/docker/run
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-TGT_DIR=$(pwd)  # the target folder where we run cow from
+TGT_DIR=$(readlink -f $(pwd))  # the target folder where we run cow from
 
 export USER_ID=$(id -u)
 
 CUR_FILE=$(readlink -f "$0")
 CUR_DIR=$(dirname $CUR_FILE)
+COW_DIR=$(dirname $CUR_DIR)
 
-cd $CUR_DIR && \
-docker-compose run -e UID=$USER_ID -u $USER_ID --rm -v "$TGT_DIR:/mnt" -w /mnt cow_dev $@
+run_docker_compose()
+{
+    cd $CUR_DIR && \
+    docker-compose run -e UID=$USER_ID -e COW_DIR="$COW_DIR" -u $USER_ID --rm -v "$COW_DIR:$COW_DIR" -v "$TGT_DIR:$TGT_DIR" -v "$CUR_DIR:$CUR_DIR" -w "$TGT_DIR" $1 ${@:2}
+}
+
+if [ ! -z "$SKIP_RUN_EXEC" ] ; then
+    return;
+fi
+
+run_docker_compose cow_dev $@

--- a/docker/run
+++ b/docker/run
@@ -1,17 +1,41 @@
 #!/bin/bash
 
-TGT_DIR=$(readlink -f $(pwd))  # the target folder where we run cow from
+# Portable versions of the path functions (should work on Linux, MacOS and Windows)
+function _dirname() { python -c 'import sys; from os.path import realpath, dirname; print(dirname(realpath(sys.argv[-1])))' $@ ; }
+function _realpath() { python -c 'import sys; from os.path import realpath; print(realpath(sys.argv[-1]))' $@ ; }
+
+TGT_DIR=$(_realpath -f $(pwd))  # the target folder where we run cow from
 
 export USER_ID=$(id -u)
 
-CUR_FILE=$(readlink -f "$0")
-CUR_DIR=$(dirname $CUR_FILE)
-COW_DIR=$(dirname $CUR_DIR)
+CUR_FILE=$(_realpath "$0")
+CUR_DIR=$(_dirname $CUR_FILE)
+COW_DIR=$(_dirname $CUR_DIR)
+
+export GIT_CONFIG=$(git config --show-origin --global -l | head -n 1 | awk '{ print substr($1, index($1, ":")+1); }')
+
+if grep -q 'XDEBUG_HOST=localhost' "$CUR_DIR/.env" ; then
+    if [ "$(uname)" = "Darwin" ] ; then
+        ## Docker for Mac is run within a VM, so container localhost will be the VM
+        ## the host machine can be referenced by a special DNS - host.docker.internal
+        ## see https://docs.docker.com/docker-for-mac/networking/
+        export XDEBUG_HOST='host.docker.internal'
+    fi
+fi
 
 run_docker_compose()
 {
     cd $CUR_DIR && \
-    docker-compose run -e UID=$USER_ID -e COW_DIR="$COW_DIR" -u $USER_ID --rm -v "$COW_DIR:$COW_DIR" -v "$TGT_DIR:$TGT_DIR" -v "$CUR_DIR:$CUR_DIR" -w "$TGT_DIR" $1 ${@:2}
+    docker-compose run --rm \
+        -e UID=$USER_ID \
+        -e COW_DIR="$COW_DIR" \
+        -e GIT_CONFIG="$GIT_CONFIG" \
+        -u $USER_ID \
+        -v "$COW_DIR:$COW_DIR" \
+        -v "$TGT_DIR:$TGT_DIR" \
+        -v "$CUR_DIR:$CUR_DIR" \
+        -w "$TGT_DIR" \
+        $1 ${@:2}
 }
 
 if [ ! -z "$SKIP_RUN_EXEC" ] ; then

--- a/docker/test
+++ b/docker/test
@@ -2,7 +2,11 @@
 
 # Run COW tests (phpunit)
 
+# Portable versions of the path functions (should work on Linux, MacOS and Windows)
+function _dirname() { python -c 'import sys; from os.path import realpath, dirname; print(dirname(realpath(sys.argv[-1])))' $@ ; }
+function _realpath() { python -c 'import sys; from os.path import realpath; print(realpath(sys.argv[-1]))' $@ ; }
+
 SKIP_RUN_EXEC="1"
-. "$(dirname $(readlink -f "$0"))/run"
+. "$(_dirname $(_realpath "$0"))/run"
 
 run_docker_compose cow_test $@

--- a/docker/test
+++ b/docker/test
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Run XDebug session for COW
+# Run COW tests (phpunit)
 
 SKIP_RUN_EXEC="1"
 . "$(dirname $(readlink -f "$0"))/run"
 
-run_docker_compose cow_debug $@
+run_docker_compose cow_test $@

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ Assuming you have docker, docker-compose and bash installed, you don't need any 
 
 E.g: `../cow/docker/run release:create 4.5.1`
 
+Read [docker docs](./docker/README.md) for more info
+
 ### Native
 
 You can install this globally with the following commands


### PR DESCRIPTION
Adds xdebug capability to the docker container so it's debuggable by a localhost IDE.

The debug mode should work seamlessly for 127.0.0.1:9000 by running `./cow/docker/dbg` script (syntactically identical to `./cow/docker/run` and to `./cow/bin/cow`)