### PR TITLE
NEW Expose full release version object to changelog template

### DIFF
--- a/src/Model/Release/Version.php
+++ b/src/Model/Release/Version.php
@@ -179,7 +179,7 @@ class Version
     }
 
     /**
-     * Get stable version this version is targetting (ignoring rc, beta, etc)
+     * Get stable version this version is targeting (ignoring rc, beta, etc)
      *
      * @return string
      */

--- a/src/Utility/ChangelogRenderer.php
+++ b/src/Utility/ChangelogRenderer.php
@@ -54,7 +54,10 @@ class ChangelogRenderer
 
         return (new Template())->renderTemplateStringWithContext(
             $template,
-            ['logs' => $logs, 'version' => $version->getValue()]
+            [
+                'logs' => $logs,
+                'version' => $version,
+            ]
         );
     }
 

--- a/src/Utility/Template.php
+++ b/src/Utility/Template.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Cow\Utility;
 
-use Exception;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -17,14 +16,8 @@ class Template
      */
     public function renderTemplateStringWithContext(string $template, array $context): string
     {
-        try {
-            $twig = new Environment(new ArrayLoader(['template' => $template]), ['autoescape' => false]);
+        $twig = new Environment(new ArrayLoader(['template' => $template]), ['autoescape' => false]);
 
-            return $twig->render('template', $context);
-        } catch (Exception $e) {
-            error_log($e->getMessage());
-
-            return '';
-        }
+        return $twig->render('template', $context);
     }
 }


### PR DESCRIPTION
We have a need to get more specific context on the release version in changelog templates - in particular, we want to output different content if the release is unstable. This tweak provides the release's full `Version` object to the template so that any exposed methods can be called on it.

Conveniently, the `Version` object implements `__toString()` so this change is completely backwards compatible with existing changelog templates.

This PR also includes a fix that halts execution if an exception is raised during changelog generation.