### PR TITLE
Use dockerhub to host image

### DIFF
--- a/docker/Dockerfile.dockerhub
+++ b/docker/Dockerfile.dockerhub
@@ -1,0 +1,67 @@
+# This is a copy paste from Dockerfile, minus xdebug and all of the multi-stage FROM commands
+
+FROM php:7.3-cli-stretch
+
+RUN apt-get update -y \
+ && apt-get install -y \
+    unzip wget \
+    libfreetype6-dev libjpeg62-turbo-dev libpng-dev libmemcached-dev \
+    zlib1g-dev libicu-dev libpq-dev libtidy-dev libzip-dev \
+    libldap-dev libgmp-dev \
+    libmagickwand-dev  # for the image magick extension (imagick)
+
+RUN docker-php-source extract \
+ && docker-php-ext-install iconv \
+ && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+ && docker-php-ext-install gd \
+ && docker-php-ext-install intl \
+ && docker-php-ext-install zip \
+ && docker-php-ext-install ldap \
+ && docker-php-ext-install gmp \
+ && docker-php-ext-install mysqli \
+ && docker-php-ext-install pgsql \
+ && docker-php-ext-install pdo \
+ && docker-php-ext-install pdo_mysql \
+ && docker-php-ext-install pdo_pgsql \
+ && docker-php-ext-install tidy \
+ && docker-php-ext-install exif \
+ && docker-php-ext-install bcmath \
+ && docker-php-ext-install bz2 \
+ && yes '' | pecl install memcached && docker-php-ext-enable memcached \
+ && yes '' | pecl install redis && docker-php-ext-enable redis \
+ && yes '' | pecl install imagick && docker-php-ext-enable imagick \
+ && yes '' | pecl install apcu && docker-php-ext-enable apcu \
+ && docker-php-source delete
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && php -r "if (hash_file('sha384', 'composer-setup.php') === '$(wget -q -O - https://composer.github.io/installer.sig)') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+ && php composer-setup.php --install-dir=/bin --filename=composer \
+ && php -r "unlink('composer-setup.php');"
+
+ARG UID=1000
+ARG GID=${UID}
+
+RUN echo "Group ID: ${GID}" \
+ && echo "User ID: ${UID}" \
+ && groupadd -f -g ${GID} cow \
+ && useradd -g ${GID} -d /home/cow -m -u ${UID} cow \
+ && mkdir -p /home/cow/.composer/cache \
+ && chown -R cow:cow /home/cow/.composer
+
+USER root
+RUN apt-get update -y \
+ && apt-get install -y git python3-pip \
+ && pip3 install -U pip \
+ && pip install transifex-client awscli \
+ && apt-get install -y ruby \
+ && gem install yamlclean
+
+USER cow
+RUN composer -vvv global require silverstripe/cow:dev-master \
+ && composer -vvv global require composer/satis ^1
+
+USER root
+RUN ln -s /home/cow/.composer/vendor/bin/cow /usr/bin/. \
+ && ln -s /home/cow/.composer/vendor/bin/satis /usr/bin/.
+
+USER cow

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,6 +1,3 @@
-# This is a copy paste from ../docker/Dockerfile, minus xdebug and all of the multi-stage FROM commands
-# hub.docker.com is setup to create an automatic build from this Dockerfile in this directory
-
 FROM php:7.3-cli-stretch
 
 RUN apt-get update -y \

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -31,6 +31,7 @@ RUN docker-php-source extract \
  && yes '' | pecl install apcu && docker-php-ext-enable apcu \
  && docker-php-source delete
 
+# If composer-setup.php fails verification then install then execution will halt
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
  && php -r "if (hash_file('sha384', 'composer-setup.php') === '$(wget -q -O - https://composer.github.io/installer.sig)') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
  && php composer-setup.php --install-dir=/bin --filename=composer \
@@ -63,3 +64,6 @@ RUN ln -s /home/cow/.composer/vendor/bin/cow /usr/bin/. \
  && ln -s /home/cow/.composer/vendor/bin/satis /usr/bin/.
 
 USER cow
+
+ENTRYPOINT ["/bin/bash"]
+WORKDIR "/home/cow"

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,4 +1,5 @@
-# This is a copy paste from Dockerfile, minus xdebug and all of the multi-stage FROM commands
+# This is a copy paste from ../docker/Dockerfile, minus xdebug and all of the multi-stage FROM commands
+# hub.docker.com is setup to create an automatic build from this Dockerfile in this directory
 
 FROM php:7.3-cli-stretch
 

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -1,0 +1,30 @@
+## Overview
+The idea with this approach is to use an image built and hosted on hub.docker.com, then manually run cow commands
+You can update the image on hub.docker.com by editing the Dockerfile in this directory.  The `latest` tag is added
+when the Dockerfile on the master branch is updated.  Tagged versions are created in hub.docker.com pushing semver
+tags to github
+
+## Running cow
+Spin up a new container by pulling an image from hub.docker.com
+```
+docker run \
+  --name mycowcontainer \
+  -dit \
+  --rm \
+  -v ~/.gitconfig:/home/cow/.gitconfig:ro \
+  -v ~/.ssh:/home/cow/.ssh:ro \
+  emteknetnz/silverstripe-cow:latest
+````
+
+SSH in to the container
+`docker exec -it mycowcontainer /bin/bash`
+
+Run cow from within the container
+```
+cd ~
+cow [commands] e.g. cow release
+```
+
+When finished
+`exit`
+`docker stop mycowcontainer`

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -1,11 +1,15 @@
 ## Overview
 The idea with this approach is to use an image built and hosted on hub.docker.com, then manually run cow commands
-You can update the image on hub.docker.com by editing the Dockerfile in this directory.  The `latest` tag is added
-when the Dockerfile on the master branch is updated.  Tagged versions are created in hub.docker.com pushing semver
-tags to github
+
+The Dockerfile in this directory is very similar to the one in the /docker directory, minus xdebug and the
+multi-stage builds
+
+You can update the image on hub.docker.com by editing the Dockerfile in this directory.
+- The `latest` tag is added when the Dockerfile on the master branch is updated in github.
+- Tagged versions are created in hub.docker.com pushing semver tags to github
 
 ## Running cow
-Spin up a new container by pulling an image from hub.docker.com
+Spin up a new container by pulling a pre-built image from hub.docker.com
 ```
 docker run \
   --name mycowcontainer \
@@ -13,6 +17,7 @@ docker run \
   --rm \
   -v ~/.gitconfig:/home/cow/.gitconfig:ro \
   -v ~/.ssh:/home/cow/.ssh:ro \
+  -v ~/.transifexrc:/home/cow/.transifexrc:ro \
   emteknetnz/silverstripe-cow:latest
 ````
 
@@ -20,11 +25,26 @@ SSH in to the container
 `docker exec -it mycowcontainer /bin/bash`
 
 Run cow from within the container
-```
-cd ~
-cow [commands] e.g. cow release
-```
+`cd ~`
+`cow [commands] e.g. cow release`
 
 When finished
 `exit`
 `docker stop mycowcontainer`
+
+## hub.docker.com setup
+Automated builds in hub.docker.com should be setup as follows: 
+
+### Build 1 (latest)
+Source type = Branch
+Source = master
+Docker Tag = latest
+Dockerfile location = Dockerfile
+Build context = /dockerhub/
+
+### Build 2 (tagged)
+Source type = Tag
+Source = /^[0-9.]+$/
+Docker Tag = {sourceref}
+Dockerfile location = Dockerfile
+Build context = /dockerhub/

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -9,28 +9,24 @@ You can update the image on hub.docker.com by editing the Dockerfile in this dir
 - Tagged versions are created in hub.docker.com pushing semver tags to github
 
 ## Running cow
-Spin up a new container by pulling a pre-built image from hub.docker.com
+Spin up a new container by pulling a pre-built image from hub.docker.com.
+You will be automatically SSH'd into the container and be in the /home/cow directory
 ```
 docker run \
   --name mycowcontainer \
-  -dit \
+  -it \
   --rm \
   -v ~/.gitconfig:/home/cow/.gitconfig:ro \
   -v ~/.ssh:/home/cow/.ssh:ro \
   -v ~/.transifexrc:/home/cow/.transifexrc:ro \
   emteknetnz/silverstripe-cow:latest
-````
-
-SSH in to the container
-`docker exec -it mycowcontainer /bin/bash`
+```
 
 Run cow from within the container
-`cd ~`
 `cow [commands] e.g. cow release`
 
-When finished
+When finished, exit the container and the container will be automatically deleted for you
 `exit`
-`docker stop mycowcontainer`
 
 ## hub.docker.com setup
 Automated builds in hub.docker.com should be setup as follows: 

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -22,7 +22,7 @@ docker run \
   emteknetnz/silverstripe-cow:latest
 ```
 
-Run cow from within the container
+Run cow from within the container.  You can read more about the cow commands used in the [standard release process](https://docs.silverstripe.org/en/4/contributing/making_a_silverstripe_core_release/#standard-release-process) and also get a [detailed breakdown](../readme.md)
 `cow [commands] e.g. cow release`
 
 When finished, exit the container and the container will be automatically deleted for you

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,13 @@ The ineptly named tool which may one day supercede the older [build tools](https
 
 ## Install
 
-### Docker
+### Use a Dockerhub version
+
+Use a pre-built docker image hosted on dockerhub
+
+Read [dockerhub docs](./dockerhub/README.md) for more info
+
+### Build a fresh docker image
 
 Assuming you have docker, docker-compose and bash installed, you don't need any extra steps and can use cow straight away through `docker/run` script. You can use it from any other place on your drive - it will automatically mount the current folder as the working directory.
 


### PR DESCRIPTION
Don't merge this just yet
----

Create a /dockerhub version of docker that integrates with dockerhubs automated build tooling

Core idea is that we host an image on dockerhub and pull that down when we need to do things with cow.  This is different from the existing solution in /docker where a fresh image of docker is built locally which will have different versions of things

The images in dockerhub are updatable by updating the Dockerfile on the master branch.  Also, adding a semver tag on this repo will create a corresponding tagged version in dockerhub