### PR TITLE
Add `include-upgrade-only` flag for `release:changelog` to include `upgrade-only` changes to the changelog

### DIFF
--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -68,6 +68,12 @@ class Release extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Include other changes in the changelog (default: false)'
+            )
+            ->addOption(
+                'include-upgrade-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Include upgrade-only changes in the changelog (default: false)'
             );
     }
 
@@ -278,5 +284,15 @@ class Release extends Command
 
         // Default value
         return false;
+    }
+
+    /**
+     * Whether to include upgrade-only changes.
+     *
+     * @return bool
+     */
+    public function getIncludeUpgradeOnly(): bool
+    {
+        return $this->input->hasOption('include-upgrade-only');
     }
 }

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -1041,6 +1041,7 @@ class Library
             'Changelog' => $plan->getChangelog(),
             'Items' => [],
             'Branching' => $plan->getBranching(null), // Only store internal value don't failover
+            'UpgradeOnly' => $plan->getLibrary()->isUpgradeOnly(), // Stored for reference, never unserialized
         ];
         foreach ($plan->getItems() as $item) {
             $content[$name]['Items'] = array_merge(

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -155,20 +155,14 @@ class PlanRelease extends Step
         $childModules = $parent->getLibrary()->getChildrenExclusive();
         foreach ($childModules as $childModule) {
             // For the given child module, guess the upgrade mechanism (upgrade or new tag)
-            if ($parent->getLibrary()->isChildUpgradeOnly($childModule->getName())) {
+            if ($childModule->isUpgradeOnly() || $parent->getLibrary()->isUpgradeOnly()) {
                 $release = $this->generateUpgradeRelease($parent, $childModule);
             } else {
                 $release = $this->proposeNewReleaseVersion($parent, $childModule);
             }
             $parent->addItem($release);
 
-            // If this release tag doesn't match an existing tag, then recurse.
-            // If the tag exists, then we are simply updating the dependency to
-            // an existing tag, so there's no need to recursie.
-            $tags = $childModule->getTags();
-            if (!array_key_exists($release->getVersion()->getValue(), $tags)) {
-                $this->generateChildReleases($release);
-            }
+            $this->generateChildReleases($release);
         }
     }
 

--- a/src/Steps/Release/PlanRelease.php
+++ b/src/Steps/Release/PlanRelease.php
@@ -557,6 +557,10 @@ class PlanRelease extends Step
             $version .= ', prior version <comment>' . $previous->getValue() . '</comment>';
         }
 
+        if ($node->getLibrary()->isUpgradeOnly()) {
+            $version .= ' <fg=yellow;options=bold>(upgrade only)</>';
+        }
+
         // Build string
         $options[$node->getLibrary()->getName()] = $formatting . $node->getLibrary()->getName() . $version;
 


### PR DESCRIPTION
This PR:

- Updates `release:plan` to include upgrade-only modules in both its plan UI and the resulting `.cow.pat.json` file. This allows us to selectively filter upgrade-only modules in other contexts.
  - This also includes a tweak to the Library serialize method to include a read-only `'UpgradeOnly'` flag in the output, which will help external visualisation tools discern between modules marked as upgrade-only and not.
- Adds a new parameter to `release:changelog`, `--include-upgrade-only`, which will avoid filtering out upgrade-only modules during changelog generation.

The goal of this PR is to introduce the ability to provide complete changelogs to auditors without manual work.

Resolves #96.