### PR TITLE
FIX detach-tagged-base to use correct prior version

### DIFF
--- a/src/Steps/Release/DetachTaggedBase.php
+++ b/src/Steps/Release/DetachTaggedBase.php
@@ -111,7 +111,7 @@ class DetachTaggedBase extends Step
 
             $headCommitHash = trim($repo->getHeadCommit()->getHash());
 
-            $base = trim($repo->run('merge-base', [$priorVersion->getValue(), $headCommitHash]));
+            $base = trim($repo->run('merge-base', [$priorVersion->getOriginalString(), $headCommitHash]));
 
             if ($base !== $headCommitHash) {
                 $commitsCount = trim($repo->run('rev-list', ['--count', "$base...HEAD"]));


### PR DESCRIPTION
We have to use the original priorVersion as-is in the plan. `Version::getValue` sometimes returns incorrect tag number (e.g. previous patch from what's in the plan). Using `getOriginalString` we take the tag as-is from the plan.