### PR TITLE
Docker setup / tune the release command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -92,7 +92,8 @@ This script is a simple shortcut for `vendor/bin/phpcs` that launches within a c
 
 #### ./docker/bin/release
 
-Same as `docker/bin/run`, but with ssh-agent reading your keys for accessing GitHub from within the container
+Same as `docker/bin/run`, but with ssh-agent reading your keys for accessing GitHub from within the container.
+Adds some extra checks for your environment (e.g. GITHUB_API_TOKEN)
 
 
 #### ./docker/bin/run

--- a/docker/bin/release
+++ b/docker/bin/release
@@ -11,5 +11,5 @@ SKIP_RUN_EXEC="1"
 
 docker_compose_pull release
 
-EXTRA_FLAGS="-e COW_MODE_RELEASE=1 $EXTRA_FLAGS"
+EXTRA_FLAGS="-e COW_MODE_RELEASE=1 $EXTRA_FLAGS -e GITHUB_API_TOKEN=$GITHUB_API_TOKEN"
 docker_compose_run release $@

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,21 @@
 if [ ! -z "$COW_MODE_RELEASE" ] ; then
     set -e
 
+    echo -n "Checking GITHUB_API_TOKEN ... "
+
+    COMPOSER_GITHUB_API_TOKEN=$(composer config -gl | grep github-oauth.github.com || true)
+
+    if [ -z "$GITHUB_API_TOKEN" -a -z "$COMPOSER_GITHUB_API_TOKEN" ] ; then
+        echo "GITHUB_API_TOKEN environment variable is undefined"
+        exit 1;
+    elif [ -z "$GITHUB_API_TOKEN" ] ; then
+        export GITHUB_API_TOKEN=$(composer config -g -- github-oauth.github.com);
+    elif [ -z "$COMPOSER_GITHUB_API_TOKEN" ] ; then
+        composer config -g github-oauth.github.com $GITHUB_API_TOKEN;
+    fi
+
+    echo "done"
+
     echo -n "Running SSH Agent... ";
     eval $(ssh-agent);
 
@@ -12,8 +27,6 @@ if [ ! -z "$COW_MODE_RELEASE" ] ; then
     echo "Scanning github.com keys, verifying github authentication"
     ssh-keyscan -H github.com 2> /dev/null 1> ~/.ssh/known_hosts
     ssh -qT git@github.com 2>&1 | grep "successfully authenticated" || (echo "GitHub authentication error" && exit 1)
-    /usr/bin/cow $@;
-    exit;
 fi
 
 if [ ! -z "$COW_MODE_TRANSIFEX" ] ; then


### PR DESCRIPTION
 - Make the release command use the host code base (same as `run`, which is more natural behaviour)
 - Add checks for GITHUB_API_TOKEN
 - Allow to configure GITHUB_API_TOKEN though both `bin/composer config and the host environment variable)