### PR TITLE
ENH Improve changelog readability

### DIFF
--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -21,6 +21,11 @@ class Changelog
     public const FORMAT_FLAT = 'flat';
 
     /**
+     * Groups changes by module
+     */
+    public const FORMAT_GROUPED_BY_LIB = 'grouped_by_lib';
+
+    /**
      * @var ChangelogLibrary
      */
     protected $rootLibrary;
@@ -117,6 +122,39 @@ class Changelog
         return $this->sortByDate($changes);
     }
 
+    protected function getChangesGroupedByLib(OutputInterface $output)
+    {
+        $libChanges = [];
+        $libraries = $this->getRootLibrary()->getAllItems(true);
+
+        foreach ($libraries as $library) {
+            $composerData = $library->getRelease()->getLibrary()->getComposerData();
+            $name = strtolower(trim($composerData['name'])); // $library->getRelease()->getLibrary()->getName();
+            $link = 'https://packagist.org/packages/'.$name;
+            $changes = $this->getLibraryLog($output, $library);
+            $libChanges[$name]['link'] = $link;
+            $libChanges[$name]['version'] = [
+                'prior' => $library->getRelease()->getPriorVersion()->getValue(),
+                'release' => $library->getRelease()->getVersion()->getValue()
+            ];
+            $libChanges[$name]['log'] = $this->sortByType($this->sortByDate($changes));
+
+            $libChanges[$name]['is_blank'] = true;
+
+            foreach ($libChanges[$name]['log'] as $groupName => $commits) {
+                if (in_array($groupName, ['Merge', 'Maintenance'], true)) {
+                    continue;
+                }
+                if (count($commits)) {
+                    $libChanges[$name]['is_blank'] = false;
+                    break;
+                }
+            }
+        }
+
+        return $libChanges;
+    }
+
     /**
      * Generate output in markdown format
      *
@@ -131,6 +169,8 @@ class Changelog
                 return $this->getMarkdownGrouped($output);
             case self::FORMAT_FLAT:
                 return $this->getMarkdownFlat($output);
+            case self::FORMAT_GROUPED_BY_LIB:
+                return $this->getMarkdownGroupedByLib($output);
             default:
                 throw new \InvalidArgumentException("Unknown changelog format $formatType");
         }
@@ -159,6 +199,98 @@ class Changelog
                 $output .= $commit->getMarkdown($this->getLineFormat(), $this->getSecurityFormat());
             }
         }
+
+        return $output;
+    }
+
+    /**
+     * Generates markdown with changelogs grouped by library (aka module)
+     *
+     * @param OutputInterface $output
+     * @return string
+     */
+    protected function getMarkdownGroupedByLib(OutputInterface $output)
+    {
+        // $groupedLog = $this->getGroupedChanges($output);
+
+        $log = $this->getChangesGroupedByLib($output);
+
+        // Convert to string and generate markdown (add list to beginning of each item)
+        $output = "\n\n## Change Log\n";
+
+        $output .= "\n### Release map\n\n";
+        $output .= "| Recipe / Module | Prior | New |\n";
+        $output .= "| --- | --- | --- |\n";
+
+        foreach ($log as $library => $data) {
+            $priorVersion = $data['version']['prior'];
+            $releaseVersion = $data['version']['release'];
+
+            $output .= '| ['.addcslashes($library, '|').']('.$data['link'].') | '.$priorVersion.' | '.$releaseVersion." |\n";
+        }
+        $output .= "\n\n";
+
+        foreach ($log as $library => $data) {
+            if ($data['is_blank']) {
+                continue;
+            }
+
+            $priorVersion = $data['version']['prior'];
+            $releaseVersion = $data['version']['release'];
+
+            $versionUpdate = " ($priorVersion -> $releaseVersion)";
+
+            $output .= "\n### $library $versionUpdate\n\n";
+
+            $output .= '| Category | Date | Commit | Author | Description |'."\n";
+            $output .= '| -------- | ---- | ------ | ------ | ----------- |'."\n";
+
+            foreach ($data['log'] as $groupName => $commits) {
+                if (empty($commits)) {
+                    continue;
+                }
+
+                if (in_array($groupName, ['Merge', 'Maintenance'], true)) {
+                    continue;
+                }
+
+                // $output .= "\n#### $groupName\n\n";
+                // foreach ($commits as $commit) {
+                //     /** @var ChangelogItem $commit */
+                //     $output .= $commit->getMarkdown($this->getLineFormat(), $this->getSecurityFormat());
+                // }
+
+                // TABLED
+
+                $groupNamePrinted = false;
+                foreach ($commits as $commit) {
+                    if (!$groupNamePrinted) {
+                        $groupNamePrinted = true;
+                        $output .= "| ".addcslashes($groupName, '|<>'). ' | ';
+                    } else {
+                        $output .= '| | ';
+                    }
+
+                    $output .= $commit->getMarkdown(
+                        // $this->getLineFormat(),
+                        ' {date} | [{shortHash}]({link}) | {author} | {shortMessage} |',
+                        ' - | - | - | [{cve}]({cveURL}) |'
+                    );
+                }
+            }
+        }
+
+        // foreach ($groupedLog as $groupName => $commits) {
+        //     if (empty($commits)) {
+        //         continue;
+        //     }
+
+        //     $output .= "\n### $groupName\n\n";
+        //     foreach ($commits as $commit) {
+        //         /** @var ChangelogItem $commit */
+        //         $output .= $commit->getMarkdown($this->getLineFormat(), $this->getSecurityFormat());
+        //     }
+        // }
 
         return $output;
     }

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -33,16 +33,16 @@ class ChangelogItem
      *
      * @var array
      */
-    protected $ignoreRules = array(
-        '/^Merge/',
-        '/branch alias/',
-        '/^Added(.*)changelog$/',
-        '/^Blocked revisions/',
-        '/^Initialized merge tracking /',
-        '/^Created (branches|tags)/',
-        '/^NOTFORMERGE/',
-        '/^\s*$/'
-    );
+    protected $ignoreRules = [
+        // '/^Merge/',
+        // '/branch alias/',
+        // '/^Added(.*)changelog$/',
+        // '/^Blocked revisions/',
+        // '/^Initialized merge tracking /',
+        // '/^Created (branches|tags)/',
+        // '/^NOTFORMERGE/',
+        // '/^\s*$/'
+    ];
 
     /**
      * Url for CVE release notes
@@ -57,21 +57,32 @@ class ChangelogItem
      * @var array
      */
     protected static $types = array(
-        'Security' => array(
-            // E.g. "[ss-2015-016]: Security fix" - deliberately case insensitive here
-            '/^(\[SS-2(\d){3}-(\d){3}\]):?/i',
-            // E.g. "[cve-2019-12345]: Security fix"
+        'Security' => [
+            // E.g. "[CVE-2019-12345]: Security fix"
             '/^(\[?CVE-(\d){4}-(\d){4,}\]?):?/i',
-        ),
-        'API Changes' => array(
-            '/^(APICHANGE|API-CHANGE|API CHANGE|API)\b:?/'
-        ),
-        'Features and Enhancements' => array(
-            '/^(ENHANCEMENT|ENHNACEMENT|ENH|FEATURE|NEW)\b:?/'
-        ),
-        'Bugfixes' => array(
-            '/^(BUG FIX|BUGFIX|BUGFUX|BUG|FIXED|FIXING|FIX)\b:?/',
-        )
+        ],
+        'API Changes' => [
+            '/^API\b:?/'
+        ],
+        'Features and Enhancements' => [
+            '/^(ENH(ANCEMENT)?|NEW)\b:?/'
+        ],
+        'Bugfixes' => [
+            '/^(FIX|BUG)\b:?/',
+        ],
+        'Documentation' => [
+            '/^(DOCS?)\b:?/',
+        ],
+        'Merge' => [
+            '/^Merge/',
+        ],
+        'Dependencies' => [
+            '/^(DEP)\b:?/',
+        ],
+        'Maintenance' => [
+            '/^(MNT)\b:?/',
+            '/\btravis\b/'
+        ],
     );
 
     /**
@@ -192,7 +203,9 @@ class ChangelogItem
             // lowercase then we'll include them in the commit message, e.g. "Fixing regex rules" as opposed to
             // "FIX Regex rules now work"
             foreach ($rules as $rule) {
-                $message = trim(preg_replace($rule, '', $message));
+                if (substr($rule, 0, 2) === '/^') {
+                    $message = trim(preg_replace($rule, '', $message));
+                }
             }
         }
 
@@ -280,11 +293,6 @@ class ChangelogItem
      */
     public function getSecurityCVE()
     {
-        // Old SS style security identifiers
-        if (preg_match('/^\[(?<ssid>SS-2(\d){3}-(\d){3})\]/i', $this->getRawMessage(), $matches)) {
-            return strtolower($matches['ssid']);
-        }
-
         // New CVE style identifiers
         if (preg_match('/^\[(?<cve>CVE-(\d){4}-(\d){4,})\]/i', $this->getRawMessage(), $matches)) {
             return strtolower($matches['cve']);

--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -1120,11 +1120,13 @@ class Library
         $data = $this->getCowData();
         // Default tagging
         if (empty($data['changelog-type'])) {
-            return Changelog::FORMAT_GROUPED;
+            return Changelog::FORMAT_GROUPED_BY_LIB;
+            // return Changelog::FORMAT_GROUPED;
         }
         // Validate tagging type
         switch ($data['changelog-type']) {
             case Changelog::FORMAT_GROUPED:
+            case Changelog::FORMAT_GROUPED_BY_LIB:
             case Changelog::FORMAT_FLAT:
                 return $data['changelog-type'];
             default:

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -347,7 +347,7 @@ class CreateChangelog extends ReleaseStep
         $repo->run("add", array($path));
         $status = $repo->run("status");
         if (stripos($status, 'Changes to be committed:')) {
-            $repo->run("commit", array("-m", "Added {$versionName} changelog"));
+            $repo->run("commit", array("-m", "MNT Added {$versionName} changelog"));
         }
     }
 }

--- a/src/Steps/Release/PublishRelease.php
+++ b/src/Steps/Release/PublishRelease.php
@@ -187,7 +187,7 @@ class PublishRelease extends ReleaseStep
         $repo->run("add", [$path]);
         $status = $repo->run("status");
         if (stripos($status, 'Changes to be committed:')) {
-            $repo->run("commit", ["-m", "Update development dependencies"]);
+            $repo->run("commit", ["-m", "MNT Update development dependencies"]);
         }
     }
 

--- a/src/Steps/Release/RewriteReleaseBranches.php
+++ b/src/Steps/Release/RewriteReleaseBranches.php
@@ -164,7 +164,7 @@ class RewriteReleaseBranches extends ReleaseStep
         $repo->run("add", array($path));
         $status = $repo->run("status");
         if (stripos($status, 'Changes to be committed:')) {
-            $repo->run("commit", array("-m", "Remove obsolete branch-alias"));
+            $repo->run("commit", array("-m", "MNT Remove obsolete branch-alias"));
         }
     }
 
@@ -230,7 +230,7 @@ class RewriteReleaseBranches extends ReleaseStep
             $repo->run("add", array($path));
             $status = $repo->run("status");
             if (stripos($status, 'Changes to be committed:')) {
-                $repo->run("commit", array("-m", "Update development dependencies"));
+                $repo->run("commit", array("-m", "MNT Update development dependencies"));
             }
         }
     }

--- a/src/Steps/Release/UpdateTranslations.php
+++ b/src/Steps/Release/UpdateTranslations.php
@@ -336,7 +336,7 @@ class UpdateTranslations extends ReleaseStep
             $status = $repo->run("status");
             if (stripos($status, 'Changes to be committed:')) {
                 $this->log($output, "Comitting changes for module " . $module->getName());
-                $repo->run("commit", array("-m", "Update translations"));
+                $repo->run("commit", array("-m", "ENH Update translations"));
             }
 
             // Do push if selected


### PR DESCRIPTION
Follow the Commit Prefix rules from RFC-9687
Split changes within changelogs by module/library
Remove outdated rules for ignoring commits (by parsing messages)

Resolves https://github.com/silverstripe/cow/issues/186
Resolves https://github.com/silverstripe/cow/issues/139