### PR TITLE
New changelog formats via Twig templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: php
 
 matrix:
   include:
-  - php: 7.1
-    env: PHPUNIT_COVERAGE_TEST=1
   - php: 7.2
     env: PHPUNIT_TEST=1 PHPCS_TEST=1
   - php: 7.3
+    env: PHPUNIT_TEST=1 PHPUNIT_COVERAGE_TEST=1
+  - php: 7.4
     env: PHPUNIT_TEST=1
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   },
   "require": {
-    "php": ">=7.1",
+    "php": "^7.2",
     "symfony/console": "^3.2",
     "symfony/process": "^3.2",
     "symfony/yaml": "^3.2",
@@ -27,7 +27,7 @@
     "knplabs/github-api": "^2.1",
     "php-http/guzzle6-adapter": "^1.1.1",
     "justinrainbow/json-schema": "^5.2",
-    "twig/twig": "^2.0"
+    "twig/twig": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "twig/twig": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7",
+    "sminnee/phpunit": "^5.7",
     "squizlabs/php_codesniffer": "^3.0"
   },
   "extra": {

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,9 @@ The changelog command takes the follow arguments and options:
 * `recipe` The recipe you're releasing
 * `--include-other-changes` If provided, uncategorised commits will also be included in an "Other changes" section.
   Note that commits which match `ChangelogItem::isIgnored()` will still be excluded, e.g. merge commits.
+* `--changelog--use-legacy-format` If provided, falls back to the old changelog format (used before Oct 2020)
+* `--changelog--audit-mode` swaps changelog format to Audit Mode, which turns on `include-upgrade-only` flag
+  and uses audit template for changelog logs generation (including every single change).
 
 **Pro-tip:** Part of this command involves plan generation and/or confirmation, and you can provide the
 `--skip-fetch-tags` option to prevent Cow from re-fetching all tags from origin if you have already done this

--- a/src/Application.php
+++ b/src/Application.php
@@ -85,7 +85,7 @@ class Application extends Console\Application
         $commands[] = new Commands\Release\Branch();
         $commands[] = new Commands\Release\Translate();
         $commands[] = new Commands\Release\Test();
-        $commands[] = new Commands\Release\Changelog();
+        $commands[] = new Commands\Release\Changelog($this);
 
         // Publish sub-commands
         $commands[] = new Commands\Release\Tag();

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,10 +6,16 @@ use SilverStripe\Cow\Commands;
 use SilverStripe\Cow\Utility\SupportedModuleLoader;
 use SilverStripe\Cow\Utility\Config;
 use SilverStripe\Cow\Utility\GitHubApi;
+use SilverStripe\Cow\Utility\Twig;
 use Symfony\Component\Console;
 
 class Application extends Console\Application
 {
+    public function createTwigEnvironment(): Twig\Environment
+    {
+        return new Twig\Environment(new Twig\Loader($this));
+    }
+
     /**
      * Get version of this module
      *
@@ -32,6 +38,14 @@ class Application extends Console\Application
         } else {
             return $this->getVersionInDir(dirname($directory));
         }
+    }
+
+    /**
+     * Returns the folder of Cow Twig templates
+     */
+    public function getTwigTemplateDir(): string
+    {
+        return realpath(__DIR__ . '/../templates');
     }
 
     /**

--- a/src/Commands/Release/Changelog.php
+++ b/src/Commands/Release/Changelog.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Cow\Commands\Release;
 
+use SilverStripe\Cow\Application;
 use SilverStripe\Cow\Steps\Release\CreateChangelog;
 use SilverStripe\Cow\Steps\Release\PlanRelease;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,14 @@ class Changelog extends Release
 
     protected $description = 'Generate changelog';
 
+    private $app;
+
+    public function __construct(Application $app, ...$args)
+    {
+        parent::__construct(...$args);
+        $this->app = $app;
+    }
+
     protected function fire()
     {
         // Get arguments
@@ -30,7 +39,7 @@ class Changelog extends Release
         $releasePlan = $buildPlan->getReleasePlan();
 
         // Generate changelog
-        $changelog = new CreateChangelog($this, $project, $releasePlan);
+        $changelog = new CreateChangelog($this, $project, $releasePlan, $this->app->createTwigEnvironment());
         $changelog->run($this->input, $this->output);
     }
 }

--- a/src/Commands/Release/Release.php
+++ b/src/Commands/Release/Release.php
@@ -74,7 +74,22 @@ class Release extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Include upgrade-only changes in the changelog (default: false)'
-            );
+            )
+            ->addOption(
+                'changelog--use-legacy-format',
+                null,
+                InputOption::VALUE_NONE,
+                'Use legacy changelog format, hardcoded in Changelog model'
+            )
+            ->addOption(
+                'changelog--audit-mode',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate changelogs for security audit.'
+                . ' Include every change, use audit template.'
+                . '(implicitly activates include-upgrade-only and include-other-changes)'
+            )
+            ;
     }
 
     protected function fire()
@@ -272,7 +287,7 @@ class Release extends Command
     public function getIncludeOtherChanges()
     {
         // If an argument was explicitly passed, use it (true)
-        if ($this->input->getOption('include-other-changes')) {
+        if ($this->input->getOption('include-other-changes') || $this->getChangelogAuditMode()) {
             return true;
         }
 
@@ -293,6 +308,26 @@ class Release extends Command
      */
     public function getIncludeUpgradeOnly(): bool
     {
-        return $this->input->getOption('include-upgrade-only');
+        return $this->input->getOption('include-upgrade-only') || $this->getChangelogAuditMode();
+    }
+
+    /**
+     * Whether to generate changelogs for Security Audit
+     *
+     * @return bool
+     */
+    public function getChangelogAuditMode(): bool
+    {
+        return $this->input->getOption('changelog--audit-mode');
+    }
+
+    /**
+     * Whether generated changelog should use the legacy format
+     *
+     * @return bool
+     */
+    public function getChangelogUseLegacyFormat(): bool
+    {
+        return $this->input->getOption('changelog--use-legacy-format');
     }
 }

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -99,6 +99,22 @@ class ChangelogItem
         $this->setIncludeOtherChanges($includeAllCommits);
     }
 
+    public function getRenderData()
+    {
+        return [
+            'type' => $this->getType(),
+            'link' => $this->getLink(),
+            'shortHash' => $this->getShortHash(),
+            'date' => $this->getDate()->format('Y-m-d'),
+            'rawMessage' => $this->getRawMessage(),
+            'message' => $this->getMessage(),
+            'shortMessage' => $this->getShortMessage(),
+            'author' => $this->getAuthor(),
+            'cve' => $this->getSecurityCVE(),
+            'cveURL' => $this->getSecurityCVE() ? $this->cveURL . $this->getSecurityCVE() : ''
+        ];
+    }
+
     /**
      * Get details this commit uses to distinguish itself from other duplicate commits.
      * Used to prevent duplicates of the same commit being added from multiple merges, which
@@ -251,12 +267,7 @@ class ChangelogItem
             return 'Security';
         }
 
-        // Fallback check to see if we should include all commits
-        if ($this->getIncludeOtherChanges()) {
-            return 'Other changes';
-        }
-
-        return null;
+        return 'Other changes';
     }
 
     /**
@@ -306,26 +317,16 @@ class ChangelogItem
         if (!isset($format)) {
             $format = ' * {date} [{shortHash}]({link}) {shortMessage} ({author})';
         }
-        $content = Format::formatString($format, [
-            'type' => $this->getType(),
-            'link' => $this->getLink(),
-            'shortHash' => $this->getShortHash(),
-            'date' => $this->getDate()->format('Y-m-d'),
-            'rawMessage' => $this->getRawMessage(), // Probably not safe to use
-            'message' => $this->getMessage(),
-            'shortMessage' => $this->getShortMessage(),
-            'author' => $this->getAuthor(),
-        ]);
+        $data = $this->getRenderData();
+
+        $content = Format::formatString($format, $data);
 
         // Append security identifier
-        if ($cve = $this->getSecurityCVE()) {
+        if (!empty($data['cve'])) {
             if (!isset($securityFormat)) {
                 $securityFormat = ' - See [{cve}]({cveURL})';
             }
-            $content .= Format::formatString($securityFormat, [
-                'cve' => $cve,
-                'cveURL' => $this->cveURL . $cve
-            ]);
+            $content .= Format::formatString($securityFormat, $data);
         }
 
         return $content . "\n";

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -267,6 +267,10 @@ class ChangelogItem
             return 'Security';
         }
 
+        if ($this->getAuthor() === 'dependabot[bot]') {
+            return 'Dependencies';
+        }
+
         return 'Other changes';
     }
 

--- a/src/Utility/Twig/Environment.php
+++ b/src/Utility/Twig/Environment.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverStripe\Cow\Utility\Twig;
+
+use Twig\Loader\LoaderInterface;
+use Twig;
+
+class Environment extends Twig\Environment
+{
+    public function __construct(LoaderInterface $loader, array $options = [])
+    {
+        if (!isset($options['cache'])) {
+            $options['cache'] = implode(
+                DIRECTORY_SEPARATOR,
+                [
+                    sys_get_temp_dir(),
+                    'cow',
+                    'twig',
+                    'cache'
+                ]
+            );
+        }
+
+        parent::__construct($loader, $options);
+    }
+}

--- a/src/Utility/Twig/Loader.php
+++ b/src/Utility/Twig/Loader.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverStripe\Cow\Utility\Twig;
+
+use Twig\Loader\FilesystemLoader;
+use SilverStripe\Cow\Application;
+
+class Loader extends FilesystemLoader
+{
+    public function __construct(Application $cow)
+    {
+        $templateDir = $cow->getTwigTemplateDir();
+
+        parent::__construct(['cow'], $templateDir);
+        $this->setPaths(['tests'], 'tests');
+    }
+}

--- a/templates/cow/changelog/logs/audit_mode.md.twig
+++ b/templates/cow/changelog/logs/audit_mode.md.twig
@@ -1,0 +1,29 @@
+{%- from "changelog/logs/macros.md.twig" import format_commit, print_section_by_type as print_section -%}
+
+{#- Sections defined by ChangelogItem::$types -#}
+{%- set SECTIONS = [
+    'Security',
+    'Features and Enhancements',
+    'Bugfixes',
+    'API Changes',
+    'Dependencies',
+    'Documentation'
+]
+-%}
+
+## Change Log
+
+{% for section in SECTIONS %}
+    {%- if commits.by_type[section]|length > 0 %}
+        {{~ print_section(commits, section, '### ' ~ section) }}
+    {% endif %}
+{% endfor %}
+
+### Other changes
+
+{% for commit in commits.all %}
+    {%- set commit = commit.getRenderData %}
+    {%- if commit.type not in SECTIONS %}
+        {{~ format_commit(commit) }}
+    {%~ endif %}
+{% endfor %}

--- a/templates/cow/changelog/logs/audit_mode.md.twig
+++ b/templates/cow/changelog/logs/audit_mode.md.twig
@@ -1,19 +1,26 @@
 {%- from "changelog/logs/macros.md.twig" import format_commit, print_section_by_type as print_section -%}
 
 {#- Sections defined by ChangelogItem::$types -#}
-{%- set SECTIONS = [
+{%- set IMPORTANT_SECTIONS = [
     'Security',
-    'Features and Enhancements',
-    'Bugfixes',
     'API Changes',
+    'Features and Enhancements',
+    'Bugfixes'
+]
+-%}
+
+{#- Sections less important than 'Other changes' -#}
+{%- set INSIGNIFICANT_SECTIONS = [
     'Dependencies',
-    'Documentation'
+    'Maintenance',
+    'Documentation',
+    'Merge'
 ]
 -%}
 
 ## Change Log
 
-{% for section in SECTIONS %}
+{% for section in IMPORTANT_SECTIONS %}
     {%- if commits.by_type[section]|length > 0 %}
         {{~ print_section(commits, section, '### ' ~ section) }}
     {% endif %}
@@ -23,7 +30,13 @@
 
 {% for commit in commits.all %}
     {%- set commit = commit.getRenderData %}
-    {%- if commit.type not in SECTIONS %}
+    {%- if commit.type not in IMPORTANT_SECTIONS and commit.type not in INSIGNIFICANT_SECTIONS %}
         {{~ format_commit(commit) }}
     {%~ endif %}
+{% endfor %}
+
+{% for section in INSIGNIFICANT_SECTIONS %}
+    {%- if commits.by_type[section]|length > 0 %}
+        {{~ print_section(commits, section, '### ' ~ section) }}
+    {% endif %}
 {% endfor %}

--- a/templates/cow/changelog/logs/by_module.md.twig
+++ b/templates/cow/changelog/logs/by_module.md.twig
@@ -1,0 +1,21 @@
+{%- from "changelog/logs/macros.md.twig" import print_section_by_type_and_module as print_section -%}
+
+{#- Sections defined by ChangelogItem::$types -#}
+{%- set SECTIONS = [
+    'Security',
+    'Features and Enhancements',
+    'Bugfixes',
+    'API Changes',
+    'Dependencies',
+    'Documentation',
+    'Other changes'
+]
+-%}
+
+## Change Log
+
+{% for section in SECTIONS %}
+    {%- if commits.by_type[section]|length > 0 %}
+        {{~ print_section(libs, commits, section, '### ' ~ section) }}
+    {% endif %}
+{% endfor -%}

--- a/templates/cow/changelog/logs/macros.md.twig
+++ b/templates/cow/changelog/logs/macros.md.twig
@@ -1,0 +1,51 @@
+{#-
+    `format_commit` formats and prints a single commit (change)
+-#}
+{%- macro format_commit(commit) %}
+  * {{ commit.date }} [{{ commit.shortHash }}]({{ commit.link }}) {{ commit.shortMessage }} ({{ commit.author }}){% if commit.cve %} - See [{{ commit.cve }}]({{ commit.cveURL }}){% endif %}
+{% endmacro -%}
+
+
+{#-
+    `print_section_by_type` formats and prints a single section (commit type, e.g. Bugfixes)
+                            if the third parameter given (`title`), prints the title for the section,
+                            but only if there are commits existing (at least one)
+-#}
+{%- macro print_section_by_type(commits, name, title) %}
+  {%~ if commits.by_type[name] %}
+    {%- if title %}
+
+      {{~ title }}
+
+    {%~ endif %}
+    {%~ for commit in commits.by_type[name] %}
+      {%- set commit = commit.getRenderData %}
+      {{~ _self.format_commit(commit) }}
+    {%~ endfor %}
+  {%~ endif %}
+{% endmacro -%}
+
+
+{#-
+    `print_section_by_type_and_module` formats and prints a single section (commit type, e.g. Bugfixes),
+                                       splitting the commits by module within the section.
+-#}
+{%- macro print_section_by_type_and_module(libraries, commits, name, title) %}
+  {%~ if commits.by_type[name] %}
+    {%- if title %}
+
+      {{~ title }}
+
+    {%~ endif %}
+    {%~ for library in libraries %}
+      {%~ if library.commits.by_type[name] %}
+
+        {{~ ' * ' ~ library.name ~ ' (' ~ library.version.prior ~ ' -> ' ~ library.version.release ~ ')' }}
+        {%~ for commit in library.commits.by_type[name] %}
+          {%- set commit = commit.getRenderData %}
+          {{~ '  ' ~ _self.format_commit(commit) }}
+        {%~ endfor %}
+      {%~ endif %}
+    {%~ endfor %}
+  {%~ endif %}
+{% endmacro -%}

--- a/templates/cow/changelog/logs/plain.md.twig
+++ b/templates/cow/changelog/logs/plain.md.twig
@@ -1,0 +1,21 @@
+{%- from "changelog/logs/macros.md.twig" import print_section_by_type as print_section -%}
+
+{#- Sections defined by ChangelogItem::$types -#}
+{%- set SECTIONS = [
+    'Security',
+    'Features and Enhancements',
+    'Bugfixes',
+    'API Changes',
+    'Dependencies',
+    'Documentation',
+    'Other changes'
+]
+-%}
+
+## Change Log
+
+{% for section in SECTIONS %}
+    {%- if commits.by_type[section]|length > 0 %}
+        {{~ print_section(commits, section, '### ' ~ section) }}
+    {% endif %}
+{% endfor -%}

--- a/templates/tests/base.twig
+++ b/templates/tests/base.twig
@@ -1,0 +1,1 @@
+{{ 'base template' -}}

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -68,26 +68,38 @@ class ChangelogItemTest extends PHPUnit_Framework_TestCase
             ['BUG FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['FIX Fixed some regex rules', 'Fixed some regex rules', 'Bugfixes'],
             ['FIX: Forgot colon', 'Forgot colon', 'Bugfixes'],
-            ['Fixed some regex rules', 'Fixed some regex rules', null],
-            ['Fixing some regex rules', 'Fixing some regex rules', null],
-            ['Fixing Behat', 'Fixing Behat', null],
+            ['Fixed some regex rules', 'Fixed some regex rules', 'Other changes'],
+            ['Fixing some regex rules', 'Fixing some regex rules', 'Other changes'],
+            ['Fixing Behat', 'Fixing Behat', 'Other changes'],
             ['Fix a typo in the docs', 'Fix a typo in the docs', 'Bugfixes'],
-            ['Fixed a typo in the docs', 'Fixed a typo in the docs', null],
-            ['FIXed a typo in the docs', 'FIXed a typo in the docs', null],
+            ['Fixed a typo in the docs', 'Fixed a typo in the docs', 'Other changes'],
+            ['FIXed a typo in the docs', 'FIXed a typo in the docs', 'Other changes'],
             ['FIX ed a typo in the docs', 'ed a typo in the docs', 'Bugfixes'],
             ['API Remove DataObject', 'Remove DataObject', 'API Changes'],
             ['API CHANGE Remove DataObject', 'CHANGE Remove DataObject', 'API Changes'],
             ['NEW Allow Python transpilation', 'Allow Python transpilation', 'Features and Enhancements'],
             ['ENH Support goland PHP extension', 'Support goland PHP extension', 'Features and Enhancements'],
-            ['[SS-2047-123] Lower doubt with cow coverage', '[SS-2047-123] Lower doubt with cow coverage', null],
-            ['[ss-2047-123] Lower doubt with cow coverage', '[ss-2047-123] Lower doubt with cow coverage', null],
-            ['[SS-2047-123]: Logins now use passwords', '[SS-2047-123]: Logins now use passwords', null],
-            ['[ss-2047-123]: Logins now use passwords', '[ss-2047-123]: Logins now use passwords', null],
+            [
+                '[SS-2047-123] Lower doubt with cow coverage',
+                '[SS-2047-123] Lower doubt with cow coverage',
+                'Other changes'
+            ],
+            [
+                '[ss-2047-123] Lower doubt with cow coverage',
+                '[ss-2047-123] Lower doubt with cow coverage',
+                'Other changes'
+            ],
+            ['[SS-2047-123]: Logins now use passwords', '[SS-2047-123]: Logins now use passwords', 'Other changes'],
+            ['[ss-2047-123]: Logins now use passwords', '[ss-2047-123]: Logins now use passwords', 'Other changes'],
             ['[CVE-1234-56789]: Fix something serious', 'Fix something serious', 'Security'],
             ['[CVE-1234-12345] Remove admin login backdoor', 'Remove admin login backdoor', 'Security'],
             ['[cve-1234-123456] added admin login backdoor', 'added admin login backdoor', 'Security'],
             ['[cve-2018-8001] testing is cool', 'testing is cool', 'Security'],
-            ['Default fallback doesn\'t categorise commit', 'Default fallback doesn\'t categorise commit', null],
+            [
+                'Default fallback doesn\'t categorise commit',
+                'Default fallback doesn\'t categorise commit',
+                'Other changes'
+            ],
         ];
     }
 

--- a/tests/Model/ChangelogTest.php
+++ b/tests/Model/ChangelogTest.php
@@ -63,6 +63,12 @@ class ChangelogTest extends PHPUnit_Framework_TestCase
                 'authorName' => 'Val Vulcan',
                 'authorDate' => new DateTime('2015-04-20 04:20:00'),
             ]),
+            new Commit($repository, sha1('gee'), [
+                'shortHash' => 'shortgee',
+                'subjectMessage' => 'MNT Some maintenance commit',
+                'authorName' => 'Val Vulcan',
+                'authorDate' => new DateTime('2015-04-20 04:21:00'),
+            ]),
             new Commit($repository, sha1('damn'), [
                 'shortHash' => 'shortdamn',
                 'subjectMessage' => '[CVE-2015-1234] Someone forgot the coffee!',
@@ -194,7 +200,8 @@ class ChangelogTest extends PHPUnit_Framework_TestCase
     {
         $result = $this->changelog->getMarkdown($this->output, $type);
 
-        $this->assertNotContains('Some uncategorised commit', $result, 'Uncategorised are ignored by default');
+        $this->assertNotContains('MNT Some maintenance commit', $result, 'Maintenance are ignored by default');
+        $this->assertContains('Some uncategorised commit', $result, 'Uncategorised are included by default');
     }
 
     /**

--- a/tests/Steps/CreateChangelogTest.php
+++ b/tests/Steps/CreateChangelogTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Cow\Tests\Steps;
 
+use SilverStripe\Cow\Application;
 use SilverStripe\Cow\Commands\Release\Changelog;
 use SilverStripe\Cow\Model\Modules\Project;
 use SilverStripe\Cow\Steps\Release\CreateChangelog;
@@ -24,7 +25,13 @@ class CreateChangelogTest extends \PHPUnit_Framework_TestCase
 
     public function testGetStepName()
     {
-        $step = new CreateChangelog(new Changelog('release:changelog'), new Project(''));
+        $app = new Application();
+        $step = new CreateChangelog(
+            new Changelog($app, 'release:changelog'),
+            new Project(''),
+            null,
+            $app->createTwigEnvironment()
+        );
 
         $this->assertSame('changelog', $step->getStepName());
     }

--- a/tests/Utility/Twig/EnvironmentTest.php
+++ b/tests/Utility/Twig/EnvironmentTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\Cow\Tests\Utility\Twig;
+
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Cow\Utility\Twig\Environment;
+use SilverStripe\Cow\Application;
+
+/**
+ * Rudimentary Twig functional tests
+ */
+class EnvironmentTest extends PHPUnit_Framework_TestCase
+{
+    private $app;
+    private $twig;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->app = new Application();
+        $this->twig = $this->app->createTwigEnvironment();
+    }
+
+    public function testTwigInitialization()
+    {
+        $this->assertNotNull($this->twig);
+    }
+
+    public function testTwigTemplateLookup()
+    {
+        $baseTplContent = $this->twig->render('@tests/base.twig');
+
+        $this->assertEquals('base template', $baseTplContent);
+    }
+}


### PR DESCRIPTION
New format for changelog logs, using Twig templates.

Requires
 - https://github.com/silverstripe/cow/pull/188
 - https://github.com/silverstripe/cow/pull/190

Changelog examples:
 - [changelog--audit-mode](https://gist.github.com/dnsl48/4d2b93225fb285f983d007266601341a)
 - [new default for recipes](https://gist.github.com/dnsl48/ee2ea5731f0ee52a2cf45c344beaa19d)

--------------------------------------------------------------------------------------------

Resolves #186
Resolves #139