### PR TITLE
Remove ENH prefix for translation commits

### DIFF
--- a/src/Steps/Release/UpdateTranslations.php
+++ b/src/Steps/Release/UpdateTranslations.php
@@ -336,7 +336,7 @@ class UpdateTranslations extends ReleaseStep
             $status = $repo->run("status");
             if (stripos($status, 'Changes to be committed:')) {
                 $this->log($output, "Comitting changes for module " . $module->getName());
-                $repo->run("commit", array("-m", "ENH Update translations"));
+                $repo->run("commit", array("-m", "Update translations"));
             }
 
             // Do push if selected


### PR DESCRIPTION
Makes translation updates fall into "Other changes" section in changelogs.