### PR TITLE
FIX Retain newlines between top delimiter and changelog

### DIFF
--- a/src/Utility/ChangelogRenderer.php
+++ b/src/Utility/ChangelogRenderer.php
@@ -88,7 +88,9 @@ class ChangelogRenderer
 
         return implode([
             $beforeLogs,
+            "\n\n",
             $newLogs,
+            "\n\n",
             $afterLogs
         ]);
     }


### PR DESCRIPTION
This was causing the first line of the changelog to be combined with the top delimiter comment, resulting in mangled rendering.