### PR TITLE
FIX Update docker image to use php 7.4

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -38,26 +38,26 @@ jobs:
       - name: Log into GitHub Packages registry
         run: |
           # The security token is issued automatically by GitHub for GitHub Actions of the same repository
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |
 
           if [[ "$GITHUB_REF" == "refs/heads/master" ]] ; then
             # If it's master, release a timestamp version
-            IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/master
+            IMAGE_ID=ghcr.io/${{ github.repository }}/master
             VERSION=$(date +%s)
 
           elif [[ "$GITHUB_REF" == "refs/tags/"* ]] ; then
             # If it's a tag, name it "release" and use the tag as the release version
-            IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/release
+            IMAGE_ID=ghcr.io/${{ github.repository }}/release
             VERSION=$COW_VERSION
 
           else
             # If it's a branch, use the branch name and timestamp as the version
             # WARNING: branch names out of [0-9a-z_-] won't work
             # Also, see "on.push.branches" rule at the top of this file (only whitelisted branches would get here)
-            IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$COW_VERSION
+            IMAGE_ID=ghcr.io/${{ github.repository }}/$COW_VERSION
             VERSION=$(date +%s)
           fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-stretch as php
+FROM php:7.4-cli as php
 
 RUN apt-get update -y \
  && apt-get install -y \
@@ -10,7 +10,7 @@ RUN apt-get update -y \
 
 RUN docker-php-source extract \
  && docker-php-ext-install iconv \
- && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+ && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
  && docker-php-ext-install gd \
  && docker-php-ext-install intl \
  && docker-php-ext-install zip \
@@ -60,10 +60,8 @@ ARG USER_ID=1000
 ARG GROUP_ID=${USER_ID}
 
 RUN composer -vvv global require silverstripe/cow:${COW_VERSION} \
- && composer -vvv global require composer/satis ^1 \
  && chmod 755 /root \
  && ln -s /root/.composer/vendor/bin/cow /usr/bin/. \
- && ln -s /root/.composer/vendor/bin/satis /usr/bin/. \
  && groupadd -f -g ${GROUP_ID} cow \
  && useradd -g ${GROUP_ID} -d /home/cow -m -u ${USER_ID} cow \
  && mkdir -p /home/cow/.composer/cache \
@@ -80,6 +78,6 @@ FROM stable as debug
 
 USER root
 RUN docker-php-source extract \
- && yes '' | pecl install xdebug-2.7.0beta1 && docker-php-ext-enable xdebug \
+ && yes '' | pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug \
  && docker-php-source delete
 USER cow

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/silverstripe/cow/master:latest
+FROM ghcr.io/silverstripe/cow/master:latest
 
 ARG USER_ID=${USER_ID}
 ARG GROUP_ID=${GROUP_ID}

--- a/readme.md
+++ b/readme.md
@@ -23,12 +23,7 @@ transparently in your terminal.
 
 When publishing a release, use the `./docker/bin/release` script. This is similar to `run`, but runs an SSH-Agent and performs some extra checks.
 
-At the time of writing this readme (2020-02-03) GitHub Packages require you to [have docker logged in](https://help.github.com/en/github/managing-packages-with-github-packages/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages) with a [GITHUB_TOKEN (scopes: `repo` and `read:packages`)](https://github.com/settings/tokens/new?scopes=repo,read:packages) even for accessing public images. This is a usability issue and they've said it's going to be [fixed in the future](https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/m-p/36148/highlight/true#M2455) (no login will be required for public images).
-
-In short you need to issue a GITHUB_TOKEN and log in as follows (only once):
-```sh
-docker login -u USERNAME -p TOKEN docker.pkg.github.com
-```
+At the time of writing this readme (2020-02-03) you will need a [GITHUB_TOKEN (scopes: `repo` and `read:packages`)](https://github.com/settings/tokens/new?scopes=repo,read:packages).
 
 Then you need to configure `composer` of your Cow distribution by running
 


### PR DESCRIPTION
Trying to use 7.3 caused issues as that's no longer supported by the modules.
Removed satis - ^1.0 is incompatible with the version of twig required by cow, and there is no stable 2.x release yet. Satis isn't actually used at all though.

Also update github action and Dockerfile to use ghcr.io (see https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry) so we don't need to add a github token to docker just to download the package.