### PR TITLE
FIX Avoid deprecated use of unsafe set-env in github actions

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Building version: $COW_VERSION"
 
           # The next line preserves $COW_VERSION across the steps
-          echo "::set-env name=COW_VERSION::$COW_VERSION"
+          echo "COW_VERSION=$COW_VERSION" >> $GITHUB_ENV
 
           # Building a new image and tag it as "cow-image"
           docker build -t 'cow-image' --target stable --build-arg COW_VERSION=$COMPOSER_COW_VERSION - < docker/Dockerfile


### PR DESCRIPTION
Fixes https://github.com/silverstripe/cow/actions/runs/2224048089