### PR TITLE
FIX Handle unicode translations in json

### DIFF
--- a/src/Steps/Release/UpdateTranslations.php
+++ b/src/Steps/Release/UpdateTranslations.php
@@ -247,7 +247,7 @@ class UpdateTranslations extends ReleaseStep
             }
 
             // Write back to local
-            file_put_contents($path, json_encode($contentJSON, JSON_PRETTY_PRINT));
+            file_put_contents($path, json_encode($contentJSON, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
         }
         $this->log($output, 'Finished merging ' . count($this->originalJson) . ' json files');
     }


### PR DESCRIPTION
Fixes this sort of thing that started happening after translations on js/json started working again after [this PR](https://github.com/silverstripe/cow/pull/203) was merged

![image](https://user-images.githubusercontent.com/4809037/166608091-0491106d-5ac8-4e1f-ad98-317c738f9a34.png)
