### PR TITLE
FIX Prevent double escaping

### DIFF
--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -240,8 +240,6 @@ class ChangelogItem
             $message = preg_replace('/\n\n^(From\:)/mi', ' $1', $message);
         }
 
-        // Encode HTML tags
-        $message = str_replace(['<', '>'], ['&lt;', '&gt;'], $message);
         return $message;
     }
 

--- a/src/Steps/Release/CreateChangelog.php
+++ b/src/Steps/Release/CreateChangelog.php
@@ -344,6 +344,9 @@ class CreateChangelog extends ReleaseStep
         $changelogData = $changelog->getChangesRenderData($output);
         $content = $this->twig->render($template, $changelogData);
 
+        // use &apos; because it's a little prettier
+        $content = str_replace('&#039;', "&apos;", $content);
+
         return $content;
     }
 

--- a/templates/cow/changelog/logs/macros.md.twig
+++ b/templates/cow/changelog/logs/macros.md.twig
@@ -20,7 +20,9 @@
     {%~ endif %}
     {%~ for commit in commits.by_type[name] %}
       {%- set commit = commit.getRenderData %}
+      {%~ autoescape false %}
       {{~ _self.format_commit(commit) }}
+      {%~ endautoescape %}
     {%~ endfor %}
   {%~ endif %}
 {% endmacro -%}
@@ -43,7 +45,9 @@
         {{~ ' * ' ~ library.name ~ ' (' ~ library.version.prior ~ ' -> ' ~ library.version.release ~ ')' }}
         {%~ for commit in library.commits.by_type[name] %}
           {%- set commit = commit.getRenderData %}
+          {%~ autoescape false %}
           {{~ '  ' ~ _self.format_commit(commit) }}
+          {%~ endautoescape %}
         {%~ endfor %}
       {%~ endif %}
     {%~ endfor %}


### PR DESCRIPTION
Issue https://github.com/silverstripe/cow/issues/199

**If you have a `/tmp/cow/twig` folder you MUST `rm -rf` the folder first so the new twig template changes are picked up.**  I'll update the release process to note this

You can test HTML messages render as `Update README&amp;lt;a&amp;gt;my html&amp;lt;/a&amp;gt; lorem (Aaron Carlino)`

You can test this by updating `ChangelogItem.php`

```
    public function getRawMessage()
    {
        return $this->getCommit()->getSubjectMessage() . '<a>my html</a> lorem';
    }
```