### PR TITLE
DEP Update symfony/yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.2",
     "symfony/console": "^3.2",
     "symfony/process": "^3.2",
-    "symfony/yaml": "^3.2",
+    "symfony/yaml": "^3.2 || ^4.0",
     "gitonomy/gitlib": "~1.0",
     "psr/log": "^1",
     "knplabs/github-api": "^2.1",


### PR DESCRIPTION
Fixes composer dependency problems in PHP linting job for `silverstripe/silverstripe-behat-extension`:
https://github.com/silverstripe/silverstripe-behat-extension/runs/7350017746?check_suite_focus=true

Job is failing because `silverstripe/silverstripe-behat-extension` requires `behat/behat ^3.9` which in turn requires `symfony/yaml` >= 4

## See also
- https://github.com/silverstripe/cow/pull/219

## Parent issue:
- https://github.com/silverstripe/gha-ci/issues/37

