### PR TITLE
DEP Update symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=5.5",
-    "symfony/console": "^3.2",
+    "symfony/console": "^3.2 || ^4.0",
     "symfony/process": "^3.2",
     "symfony/yaml": "^3.2 || ^4.0",
     "gitonomy/gitlib": "~1.0",


### PR DESCRIPTION
Follow-up to https://github.com/silverstripe/cow/pull/219

Fixes composer dependency problems in PHP linting job for `silverstripe/silverstripe-behat-extension`:
https://github.com/silverstripe/silverstripe-behat-extension/runs/7404200666?check_suite_focus=true

I missed this when doing the first one - but behat/behat requires symfony/console of at least 4.x

This change is safe - none of the remove functionality according to [the changelog](https://github.com/symfony/console/blob/6.1/CHANGELOG.md) is being used.

When merged, tag as 2.2.2