### PR TITLE
ENH Allow using .env file for github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Cow includes commands to help synchronise standardised data to all
 * `cow github:ratelimit` Check your current GitHub API rate limiting status (sync commands can use this up quickly)
 
 **Note:** All GitHub API commands require a `GITHUB_ACCESS_TOKEN` environment variable to be set before they can be
-used.
+used. It can be in the .env file (see [dev mode](#dev_mode)).
 
 ### Labels
 

--- a/src/Steps/Release/PublishRelease.php
+++ b/src/Steps/Release/PublishRelease.php
@@ -367,6 +367,9 @@ class PublishRelease extends ReleaseStep
     {
         $token = getenv('GITHUB_API_TOKEN');
         if (empty($token)) {
+            $token = $_ENV['GITHUB_API_TOKEN'];
+        }
+        if (empty($token)) {
             $token = Composer::getOAUTHToken($this->getCommandRunner($output));
         }
         if (empty($token)) {

--- a/src/Utility/GitHubApi.php
+++ b/src/Utility/GitHubApi.php
@@ -28,13 +28,14 @@ class GitHubApi
     public function getClient()
     {
         if (!$this->client) {
+            $token = getenv(self::TOKEN_ENV_VAR) ?: $_ENV[self::TOKEN_ENV_VAR];
             // Handled here rather than constructor so that exceptions will be formatted by SymfonyStyle
-            if (!getenv(self::TOKEN_ENV_VAR)) {
+            if (!$token) {
                 throw new RuntimeException(self::TOKEN_ENV_VAR . ' environment variable is not defined!');
             }
 
             $this->client = new Client();
-            $this->client->authenticate(getenv(self::TOKEN_ENV_VAR), null, Client::AUTH_HTTP_TOKEN);
+            $this->client->authenticate($token, null, Client::AUTH_HTTP_TOKEN);
         }
         return $this->client;
     }


### PR DESCRIPTION
I had issues with my github token because it wasn't using the .env file to fetch it. This resulted in confusion when the release notes API returned 404 (which is for insufficient token permissions).

## Issue
- https://github.com/silverstripeltd/product-issues/issues/691