### PR TITLE
FIX Only change constraints for recipes

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -683,6 +683,19 @@ class Library
         return $data['name'];
     }
 
+    /**
+     * Get type of this library
+     */
+    public function getType(): string
+    {
+        $data = $this->getComposerData();
+        return $data['type'] ?? '';
+    }
+
+    public function isRecipe(): bool
+    {
+        return $this->getType() === 'silverstripe-recipe';
+    }
 
     /**
      * Get link to github module

--- a/src/Steps/Release/MergeUpRelease.php
+++ b/src/Steps/Release/MergeUpRelease.php
@@ -144,7 +144,9 @@ class MergeUpRelease extends ReleaseStep
         }
 
         // Step 3. Convert constraints to the appropriate dev format
-        ConstraintStabiliser::destabiliseConstraints($output, $releasePlanNode, $isMajorBranch);
+        if ($library->isRecipe()) {
+            ConstraintStabiliser::destabiliseConstraints($output, $releasePlanNode, $isMajorBranch);
+        }
 
         // Step 4. Push branch
         if ($pushToRemote) {

--- a/src/Steps/Release/PublishRelease.php
+++ b/src/Steps/Release/PublishRelease.php
@@ -92,13 +92,17 @@ class PublishRelease extends ReleaseStep
         $this->log($output, "Releasing library <info>{$name}</info> at version <info>{$versionName}</info>");
 
         // Step 1: Rewrite composer.json to all tagged versions only
-        ConstraintStabiliser::stabiliseConstraints($output, $releasePlanNode);
+        if ($library->isRecipe()) {
+            ConstraintStabiliser::stabiliseConstraints($output, $releasePlanNode);
+        }
 
         // Step 2: Tag and push this tag
         $this->publishTag($output, $releasePlanNode);
 
         // Step 3: Rewrite composer.json to destabilise requirements
-        ConstraintStabiliser::destabiliseConstraints($output, $releasePlanNode, false);
+        if ($library->isRecipe()) {
+            ConstraintStabiliser::destabiliseConstraints($output, $releasePlanNode, false);
+        }
 
         // Step 4: Push development branch to origin
         $this->log($output, "Pushing branch <info>{$branch}</info>");

--- a/src/Steps/Release/RewriteReleaseBranches.php
+++ b/src/Steps/Release/RewriteReleaseBranches.php
@@ -67,10 +67,11 @@ class RewriteReleaseBranches extends ReleaseStep
             $this->checkoutLibrary($output, $libraryRelease->getLibrary(), $libraryRelease->getVersion());
         }
 
-        // Ensure any newly created branches have the correct 4.12.x-dev contraints
-        // need to do this because new branches would have been branched from
-        // recipes with 4.x-dev contraints
-        ConstraintStabiliser::destabiliseConstraints($output, $libraryRelease, false);
+        // Ensure any newly created branches on recipes have the correct 4.12.x-dev contraint format.
+        // Need to do this because new branches would have been branched from recipes with 4.x-dev contraint format.
+        if ($libraryRelease->getLibrary()->isRecipe()) {
+            ConstraintStabiliser::destabiliseConstraints($output, $libraryRelease, false);
+        }
     }
 
     /**


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.
Only recipes should have their constraints updated.

## Issue
- https://github.com/silverstripe/.github/issues/33