### PR TITLE
BUG Treat commit with same message as distinct if they are on different seconds

### DIFF
--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -125,7 +125,7 @@ class ChangelogItem
     public function getDistinctDetails()
     {
         // Date, author, and message
-        return $this->getAuthor() . '-' . $this->getDate()->format('Y-m-d') . '-' . $this->getRawMessage();
+        return $this->getAuthor() . '-' . $this->getDate()->format('Y-m-d H:i:s') . '-' . $this->getRawMessage();
     }
 
     /**


### PR DESCRIPTION
If you have two commits on the same day with the same message, cow thinks they are duplicate and removes one.