### PR TITLE
FIX Add SS-2023-001 style security commits.

### DIFF
--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -301,9 +301,13 @@ class ChangelogItem
      */
     public function getSecurityCVE()
     {
-        // New CVE style identifiers
+        // New CVE style identifiers (e.g. CVE-2023-32302)
         if (preg_match('/^\[(?<cve>CVE-(\d){4}-(\d){4,})\]/i', $this->getRawMessage(), $matches)) {
             return strtolower($matches['cve']);
+        }
+        // Non-CVE style identifiers (e.g. SS-2023-001)
+        if (preg_match('/^\[(?<ss>SS-(\d){4}-(\d){3})\]/i', $this->getRawMessage(), $matches)) {
+            return strtolower($matches['ss']);
         }
     }
 

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -82,15 +82,15 @@ class ChangelogItemTest extends TestCase
             [
                 '[SS-2047-123] Lower doubt with cow coverage',
                 '[SS-2047-123] Lower doubt with cow coverage',
-                'Other changes'
+                'Security'
             ],
             [
                 '[ss-2047-123] Lower doubt with cow coverage',
                 '[ss-2047-123] Lower doubt with cow coverage',
-                'Other changes'
+                'Security'
             ],
-            ['[SS-2047-123]: Logins now use passwords', '[SS-2047-123]: Logins now use passwords', 'Other changes'],
-            ['[ss-2047-123]: Logins now use passwords', '[ss-2047-123]: Logins now use passwords', 'Other changes'],
+            ['[SS-2047-123]: Logins now use passwords', '[SS-2047-123]: Logins now use passwords', 'Security'],
+            ['[ss-2047-123]: Logins now use passwords', '[ss-2047-123]: Logins now use passwords', 'Security'],
             ['[CVE-1234-56789]: Fix something serious', 'Fix something serious', 'Security'],
             ['[CVE-1234-12345] Remove admin login backdoor', 'Remove admin login backdoor', 'Security'],
             ['[cve-1234-123456] added admin login backdoor', 'added admin login backdoor', 'Security'],


### PR DESCRIPTION
Noticed this in passing while reviewing another change. We sometimes use this old format for security vulnerabilities that we can't issue CVEs for, such as [SS-2023-001](https://www.silverstripe.org/download/security-releases/SS-2023-001)

Not sure why this was ever changed to mark them as "other" changes, but we definitely do treat these the same as we do with security issues we _can_ assign CVEs to.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/805