### PR TITLE
ENH Handle TLN commit prefix

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -26,7 +26,7 @@ class Application extends Console\Application
 
     public function createTwigEnvironment(): Twig\Environment
     {
-        return new Twig\Environment(new Twig\Loader($this));
+        return new Twig\Environment(new Twig\Loader($this), ['cache' => false]);
     }
 
     /**

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -70,6 +70,9 @@ class ChangelogItem
         'Dependencies' => [
             '/^(DEP)\b:?/',
         ],
+        'Translations' => [
+            '/^(TLN)\b:?/',
+        ],
         'Maintenance' => [
             '/^(MNT)\b:?/',
             '/\btravis\b/'

--- a/templates/cow/changelog/logs/audit_mode.md.twig
+++ b/templates/cow/changelog/logs/audit_mode.md.twig
@@ -14,6 +14,7 @@
     'Dependencies',
     'Maintenance',
     'Documentation',
+    'Translations',
     'Merge'
 ]
 -%}

--- a/templates/cow/changelog/logs/by_module.md.twig
+++ b/templates/cow/changelog/logs/by_module.md.twig
@@ -8,6 +8,7 @@
     'API Changes',
     'Dependencies',
     'Documentation',
+    'Translations',
     'Other changes'
 ]
 -%}

--- a/templates/cow/changelog/logs/plain.md.twig
+++ b/templates/cow/changelog/logs/plain.md.twig
@@ -8,6 +8,7 @@
     'API Changes',
     'Dependencies',
     'Documentation',
+    'Translations',
     'Other changes'
 ]
 -%}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/135

There's also an additional commit in here to disable the twig caching which is annoying as it requires the user to `rm -rf /tmp/cow/twig/cache` in order to get the twig template changes. Given this is so easy to miss it may mean we accidentally leave out the translation commits in a changelog in the future.  There is seemingly zero performance difference with the caching disabled

The test this I created mock 5.1.1 release - I made this a patch release to ensure I didn't accidentally create new 5.2 branches

- ensure cow .env file has DEV_MODE=1
- cow release:create -vvv 5.1.1 silverstripe/recipe-kitchen-sink
- cow release:plan -vvv 5.1.1 silverstripe/recipe-kitchen-sink
- Update the readme in framework and add a commit 'TLN My translation commit'
- cow release:changelog -vvv --skip-fetch-tags --include-other-changes --include-upgrade-only 5.1.1 silverstripe/recipe-kitchen-sink

