### PR TITLE
FIX Ensure changelog passes linting

### DIFF
--- a/src/Model/Changelog/Changelog.php
+++ b/src/Model/Changelog/Changelog.php
@@ -264,7 +264,7 @@ class Changelog
         $groupedLog = $this->getGroupedChanges($output, $this->getLegacyChangelogCommitFilter());
 
         // Convert to string and generate markdown (add list to beginning of each item)
-        $output = "\n\n## Change Log\n";
+        $output = "\n\n## Change log\n";
         foreach ($groupedLog as $groupName => $commits) {
             if (empty($commits)) {
                 continue;

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -324,7 +324,7 @@ class ChangelogItem
     public function getMarkdown($format = null, $securityFormat = null)
     {
         if (!isset($format)) {
-            $format = ' * {date} [{shortHash}]({link}) {shortMessage} ({author})';
+            $format = '- {date} [{shortHash}]({link}) {shortMessage} ({author})';
         }
         $data = $this->getRenderData();
 

--- a/src/Utility/ChangelogRenderer.php
+++ b/src/Utility/ChangelogRenderer.php
@@ -23,6 +23,11 @@ class ChangelogRenderer
     public const BOTTOM_DELIMITER = '<!--- Changes above this line will be automatically regenerated -->';
 
     /**
+     * This prevents certain linting rules from being run against the commits
+     */
+    public const SKIP_LINTING = '<!-- markdownlint-disable proper-names enhanced-proper-names -->';
+
+    /**
      * Renders a basic changelog, with a version title and the provided logs.
      *
      * @param Version $version
@@ -75,7 +80,12 @@ class ChangelogRenderer
 
         // If the top delimiter doesn't exist, fall back to appending the logs
         if ($topDelimiterPos === false) {
-            return $existingChangelog . self::TOP_DELIMITER . $newLogs . self::BOTTOM_DELIMITER;
+            return $existingChangelog
+                . self::TOP_DELIMITER
+                . "\n"
+                . self::SKIP_LINTING
+                . $newLogs
+                . self::BOTTOM_DELIMITER;
         }
 
         // Extract the content preceding the logs (including the top delimiter itself)
@@ -87,10 +97,9 @@ class ChangelogRenderer
             : substr($existingChangelog, $bottomDelimiterPos);
 
         return implode([
-            $beforeLogs,
+            $beforeLogs . "\n" . self::SKIP_LINTING,
             "\n\n",
             $newLogs,
-            "\n\n",
             $afterLogs
         ]);
     }
@@ -104,7 +113,7 @@ class ChangelogRenderer
     private function delimitLogs(string $logs): string
     {
         return implode("\n\n", [
-            self::TOP_DELIMITER,
+            self::TOP_DELIMITER . "\n" . self::SKIP_LINTING,
             $logs,
             self::BOTTOM_DELIMITER
         ]);

--- a/templates/cow/changelog/logs/by_module.md.twig
+++ b/templates/cow/changelog/logs/by_module.md.twig
@@ -13,10 +13,11 @@
 ]
 -%}
 
-## Change Log
+## Change log
 
 {% for section in SECTIONS %}
-    {%- if commits.by_type[section]|length > 0 %}
-        {{~ print_section(libs, commits, section, '### ' ~ section) }}
-    {% endif %}
+{#- Don't indent these, as it will end up with indents in the final changelog which fails linting. -#}
+{%- if commits.by_type[section]|length > 0 %}
+    {{~ print_section(libs, commits, section) }}
+{% endif %}
 {% endfor -%}

--- a/templates/cow/changelog/logs/macros.md.twig
+++ b/templates/cow/changelog/logs/macros.md.twig
@@ -2,9 +2,14 @@
     `format_commit` formats and prints a single commit (change)
 -#}
 {%- macro format_commit(commit) %}
-  * {{ commit.date }} [{{ commit.shortHash }}]({{ commit.link }}) {{ commit.shortMessage }} ({{ commit.author }}){% if commit.cve %} - See [{{ commit.cve }}]({{ commit.cveURL }}){% endif %}
+- {{ commit.date }} [{{ commit.shortHash }}]({{ commit.link }}) {{ commit.shortMessage }} ({{ commit.author }}){% if commit.cve %} - See [{{ commit.cve }}]({{ commit.cveURL }}){% endif %}
 {% endmacro -%}
 
+{#-
+    `anchor_for_type` generates an anchor for a changelog heading.
+    Must be on one line to avoid creating new lines which fail linting.
+-#}
+{%- macro anchor_for_type(type) %}{{' {#changelog-' ~ type|lower|replace({' ': '-'}) ~ '}' }}{% endmacro -%}
 
 {#-
     `print_section_by_type` formats and prints a single section (commit type, e.g. Bugfixes)
@@ -32,17 +37,15 @@
     `print_section_by_type_and_module` formats and prints a single section (commit type, e.g. Bugfixes),
                                        splitting the commits by module within the section.
 -#}
-{%- macro print_section_by_type_and_module(libraries, commits, name, title) %}
+{%- macro print_section_by_type_and_module(libraries, commits, name) %}
   {%~ if commits.by_type[name] %}
-    {%- if title %}
-
-      {{~ title }}
-
+    {%- if name %}
+      {{~ '### ' ~ name|capitalize ~ _self.anchor_for_type(name) }}
     {%~ endif %}
     {%~ for library in libraries %}
       {%~ if library.commits.by_type[name] %}
 
-        {{~ ' * ' ~ library.name ~ ' (' ~ library.version.prior ~ ' -> ' ~ library.version.release ~ ')' }}
+        {{~ '- ' ~ library.name ~ ' (' ~ library.version.prior ~ ' -> ' ~ library.version.release ~ ')' }}
         {%~ for commit in library.commits.by_type[name] %}
           {%- set commit = commit.getRenderData %}
           {%~ autoescape false %}

--- a/templates/cow/changelog/logs/plain.md.twig
+++ b/templates/cow/changelog/logs/plain.md.twig
@@ -13,7 +13,7 @@
 ]
 -%}
 
-## Change Log
+## Change log
 
 {% for section in SECTIONS %}
     {%- if commits.by_type[section]|length > 0 %}

--- a/tests/Model/ChangelogTest.php
+++ b/tests/Model/ChangelogTest.php
@@ -113,7 +113,7 @@ class ChangelogTest extends TestCase
     {
         $result = $this->changelog->getMarkdown($this->output, Changelog::FORMAT_GROUPED);
 
-        $this->assertStringContainsString('## Change Log', $result);
+        $this->assertStringContainsString('## Change log', $result);
         $this->assertStringContainsString('### Security', $result);
         $this->assertStringContainsString('### Bugfixes', $result);
         $this->assertStringContainsString('### Features and Enhancements', $result);


### PR DESCRIPTION
Tested this with a dummy run and it works well.
Some commit messages may still introduce unexpected linting issues - we can look at whether the current set of rule exclusions is appropriate if/when that happens, but for now those rules are the only ones that need excluding. I don't want to exclude linting altogether for them in case some commit message has something which would result in poorly rendered markdown.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1544