### PR TITLE
FIX Handle double underscored PR titles in changelog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "php-http/guzzle7-adapter": "^1.0.0",
     "guzzlehttp/guzzle": "^7.5.0",
     "justinrainbow/json-schema": "^5.2.12",
-    "twig/twig": "^3.5.0"
+    "twig/twig": "^3.5.0",
+    "erusev/parsedown": "^1.7"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Cow\Model\Changelog;
 use DateTime;
 use Gitonomy\Git\Commit;
 use SilverStripe\Cow\Utility\Format;
+use Parsedown;
 
 /**
  * Represents a line-item in a changelog
@@ -200,7 +201,7 @@ class ChangelogItem
     }
 
     /**
-     * Gets message with type tag stripped
+     * Gets message with type tag stripped and escaped if it contains markdown
      *
      * @return string markdown safe string
      */
@@ -221,6 +222,16 @@ class ChangelogItem
                     }
                 }
             }
+        }
+        // Escape the whole string if it contains markdown so that it won't fail CI linting
+        $parsedown = new Parsedown();
+        $parsed = $parsedown->text($message);
+        // remove <p> tags that were just added
+        $parsed = preg_replace(['#^<p>#', '#</p>$#'], '', $parsed);
+        // compare with original message, if it's changed it means there was markdown in there
+        if ($message !== $parsed) {
+            $message = str_replace('`', '', $message);
+            $message = "`$message`";
         }
 
         return $message;

--- a/tests/Model/Changelog/ChangelogItemTest.php
+++ b/tests/Model/Changelog/ChangelogItemTest.php
@@ -100,6 +100,9 @@ class ChangelogItemTest extends TestCase
                 'Default fallback doesn\'t categorise commit',
                 'Other changes'
             ],
+            // __CLASS__ and __TRAIT__ will be treated as markdown
+            ['DOC Lorem __CLASS__ ipsum', '`Lorem __CLASS__ ipsum`', 'Documentation'],
+            ['DOC Lorem `__TRAIT__` ipsum', '`Lorem __TRAIT__ ipsum`', 'Documentation'],
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/844

There was a `__CLASS__ ` in one of the PR titles. The new markdown linter didn't like this