### PR TITLE
ENH Do not prefix tag with v

### DIFF
--- a/src/Steps/Release/PublishRelease.php
+++ b/src/Steps/Release/PublishRelease.php
@@ -162,7 +162,7 @@ class PublishRelease extends ReleaseStep
         // Log release
         $version = $release->getVersion();
         $tag = $version->getValue();
-        $this->log($output, "Creating github release <info>{$org}/{$repo} v{$tag}</info>");
+        $this->log($output, "Creating github release <info>{$org}/{$repo} {$tag}</info>");
 
         $client = $this->getGithubClient($output);
         /** @var Repo $reposAPI */


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/844

In the console log it prefixes the tag with v, which is wrong and makes it look like cow is doing something bad
