### PR TITLE
ENH Skip repositories we've already tagged

### DIFF
--- a/src/Model/Modules/Library.php
+++ b/src/Model/Modules/Library.php
@@ -287,6 +287,20 @@ class Library
     }
 
     /**
+     * Check if a tag exists in the repository
+     */
+    public function hasTag(string $tag): bool
+    {
+        $repo = $this->getRepository();
+        if ($this->getProject()->getFetchTags()) {
+            // Fetch remote tags from origin first
+            $repo->run('fetch', ['--tags']);
+        }
+
+        return (bool) $repo->run('tag', ['--list', $tag]);
+    }
+
+    /**
      * Tag this module
      *
      * @param string $tag

--- a/src/Steps/Release/PublishRelease.php
+++ b/src/Steps/Release/PublishRelease.php
@@ -118,6 +118,11 @@ class PublishRelease extends ReleaseStep
             die();
         }
 
+        if ($this->hasTag($releasePlanNode)) {
+            $this->log($output, "Library <info>{$name}</info> has already been released. <comment>Skipping.</comment>");
+            return;
+        }
+
         $versionName = $releasePlanNode->getVersion()->getValue();
         $this->log($output, "Releasing library <info>{$name}</info> at version <info>{$versionName}</info>");
 
@@ -163,6 +168,15 @@ class PublishRelease extends ReleaseStep
         $this->log($output, 'Tagging complete');
     }
 
+    /**
+     * Check if this release node already has the tag we're going to release
+     */
+    protected function hasTag(LibraryRelease $releasePlan): bool
+    {
+        $library = $releasePlan->getLibrary();
+        $tag = $releasePlan->getVersion()->getValue();
+        return $library->hasTag($tag);
+    }
 
     /**
      * Update github release notes via github API


### PR DESCRIPTION
If an error occurs when cow has already tagged 15 repos, we want to be able to rerun the release command and skip anything we've already tagged.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/877