### PR TITLE
ENH Remove CMS 4 workarounds

### DIFF
--- a/src/Commands/Release/MergeUp.php
+++ b/src/Commands/Release/MergeUp.php
@@ -8,9 +8,8 @@ use SilverStripe\Cow\Steps\Release\MergeUpRelease;
 use Symfony\Component\Console\Input\InputOption;
 
 /**
- * Merge up released commits to the major branch and optionally remove x.y-release branch.
- * E.g. if you just released 4.12.0, this will merge 4.12-release up to 4.12, and then 4.12
- * up to 4.
+ * Merge up released commits to the major branch and optionally remove x.y branch.
+ * E.g. if you just released 4.12.0, this will merge 4.12 up to 4.
  */
 class MergeUp extends Release
 {

--- a/src/Model/Release/ComposerConstraint.php
+++ b/src/Model/Release/ComposerConstraint.php
@@ -128,16 +128,6 @@ class ComposerConstraint
             return;
         }
 
-        // HACK for graphql where there's dual support for 3.x-dev || 4.x-dev
-        // This may come also come in as something like 3.8.x-dev || 4.1.x-dev
-        // This temporarily converts it to something that's "semver compatible"
-        // This is only for CMS 4. CMS 5 will ignore this
-        if ($name == 'silverstripe/graphql') {
-            if (preg_match('#3[\.0-9]*\.x-dev \|\| (4[\.0-9]*\.x-dev)#', $constraint, $matches)) {
-                $constraint = $matches[1];
-            }
-        }
-
         // Parse type
         $parsed = static::parse($constraint);
         if (!$parsed) {

--- a/src/Steps/Release/MergeUpRelease.php
+++ b/src/Steps/Release/MergeUpRelease.php
@@ -10,9 +10,8 @@ use SilverStripe\Cow\Application;
 use SilverStripe\Cow\Utility\ConstraintStabiliser;
 
 /**
- * Merge up released commits to the major branch and optionally remove x.y-release branch.
- * E.g. if you just released 4.12.0, this will merge 4.12-release up to 4.12, and then 4.12
- * up to 4.
+ * Merge up released commits to the major branch.
+ * E.g. if you just released 4.12.0, this will merge 4.12 up to 4.
  */
 class MergeUpRelease extends ReleaseStep
 {

--- a/src/Steps/Release/RewriteReleaseBranches.php
+++ b/src/Steps/Release/RewriteReleaseBranches.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * This step performs the below tasks on the checked out project:
  * - Recursively checks out the correct release branch matching the selected version. E.g. the dev
- *   branch may be 3.2, but if doing a 3.3 release we need to check out the 3.3-release branch
+ *   branch may be 3.2, but if doing a 3.3 release we need to check out the 3.3 branch
  *   instead. This could either be a new branch and needs to be branched from 3 / 3.3, or it could
  *   be an existing branch that needs pulling from origin.
  * - As part of the above, the new patch release branch (e.g. 3.3 for the above example) is created


### PR DESCRIPTION
Also remove references to the defunct `*-release` branch naming convention

## Issue

- https://github.com/silverstripe/.github/issues/407