### PR TITLE
DEP Switch to markdown parser to thephpleague/commonmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "guzzlehttp/guzzle": "^7.5.0",
         "justinrainbow/json-schema": "^5.2.12",
         "twig/twig": "^3.5.0",
-        "erusev/parsedown": "^1.7"
+        "league/commonmark": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/src/Model/Changelog/ChangelogItem.php
+++ b/src/Model/Changelog/ChangelogItem.php
@@ -5,7 +5,7 @@ namespace SilverStripe\Cow\Model\Changelog;
 use DateTime;
 use Gitonomy\Git\Commit;
 use SilverStripe\Cow\Utility\Format;
-use Parsedown;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * Represents a line-item in a changelog
@@ -224,10 +224,10 @@ class ChangelogItem
             }
         }
         // Escape the whole string if it contains markdown so that it won't fail CI linting
-        $parsedown = new Parsedown();
-        $parsed = $parsedown->text($message);
+        $converter = new CommonMarkConverter();
+        $parsed = $converter->convert($message)->getContent();
         // remove <p> tags that were just added
-        $parsed = preg_replace(['#^<p>#', '#</p>$#'], '', $parsed);
+        $parsed = preg_replace(['#^<p>#', '#</p>\n?$#'], '', $parsed);
         // compare with original message, if it's changed it means there was markdown in there
         if ($message !== $parsed) {
             $message = str_replace('`', '', $message);


### PR DESCRIPTION
Issue https://github.com/silverstripe/cow/issues/270

Note that cow has `composer.lock` gitignored

Change is covered by unit tests in [ChangelogItemTest](https://github.com/silverstripe/cow/blob/master/tests/Model/Changelog/ChangelogItemTest.php)

Changed line is the only one that uses parses an markdown

I've tried running on a prior release (6.1.0-beta1) it created a changelog correctly, including commits with markdown in them - it correctly surronded commit message with backticks e.g.

```
  - 2025-06-23 [a7cb1b1](https://github.com/silverstripe/silverstripe-linkfield/commit/a7cb1b12822fbedd87445eef4196b1c5eb5cb93c) `Update docs/en/01_basic_usage.md` (Mojmir Fendek)
```